### PR TITLE
Async functional test

### DIFF
--- a/spec/integration/async_publisher_spec.rb
+++ b/spec/integration/async_publisher_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "an asynchronous publish", :integration => true do
+  let(:exchange_name) { "actions" }
+  let(:payload) { "Caught a Crim!" }
+  let(:route) { "dog.bounty.update" }
+
+  it "publishes a message to rabbitmq" do
+    setup_subscriber(exchange_name, route) do |message|
+      $message = message
+    end
+    ::ActivePublisher.publish_async(route, payload, exchange_name)
+    verify_expectation_within(1.0) do
+      expect($message).to eq({:routing_key => route, :payload => payload})
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'active_publisher'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "active_publisher"
+require "support/setup_subscriber"
+
+::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter.new
 
 def verify_expectation_within(number_of_seconds, check_every = 0.02)
   waiting_since = ::Time.now

--- a/spec/support/setup_subscriber.rb
+++ b/spec/support/setup_subscriber.rb
@@ -1,0 +1,17 @@
+def setup_subscriber(exchange_name, route)
+  connection = ::ActivePublisher::Connection.connection
+  channel = connection.create_channel
+  exchange = channel.topic(exchange_name)
+
+  if ::RUBY_PLATFORM == "java"
+    channel.queue("").bind(exchange, :routing_key => route).subscribe do |metadata, payload|
+      message = {:routing_key => metadata.routing_key, :payload => payload}
+      yield message
+    end
+  else
+    channel.queue("").bind(exchange, :routing_key => route).subscribe do |delivery_info, _, payload|
+      message = {:routing_key => delivery_info.routing_key, :payload => payload}
+      yield message
+    end
+  end
+end


### PR DESCRIPTION
This is just an end-to-end test of the asynchronous publishing. In order to make this test clean I refactored the existing integration test so it could share the logic for setting up the subscriber.

In the future I think it will make sense to reset the rabbit connection after each integration test to avoid potential timing issues in the functional tests. Or perhaps add `action_subscriber` as a development dependency and use that to setup and cleanup the subscribers?

/cc @film42 @andrew-lewin @liveh2o 
