### PR TITLE
Error handler

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -120,10 +120,7 @@ module ActivePublisher
                 # Do not requeue the message because something else horrible happened.
                 @current_message = nil
 
-                # Log the error.
-                logger.info unknown_error.class
-                logger.info unknown_error.message
-                logger.info unknown_error.backtrace.join("\n")
+                ::ActivePublisher.configuration.error_handler.call(unknown_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
 
                 # TODO: Find a way to bubble this out of the thread for logging purposes.
                 # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -2,7 +2,8 @@ require "yaml"
 
 module ActivePublisher
   class Configuration
-    attr_accessor :heartbeat,
+    attr_accessor :error_handler,
+                  :heartbeat,
                   :host,
                   :hosts,
                   :password,
@@ -16,6 +17,11 @@ module ActivePublisher
     CONFIGURATION_MUTEX = ::Mutex.new
 
     DEFAULTS = {
+      :error_handler => lambda { |error, env_hash|
+        ::ActivePublisher::Logging.logger.error(error.class)
+        ::ActivePublisher::Logging.logger.error(error.message)
+        ::ActivePublisher::Logging.logger.error(error.backtrace.join("\n")) if error.backtrace.respond_to?(:join)
+      },
       :heartbeat => 5,
       :host => "localhost",
       :hosts => [],

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -6,4 +6,12 @@ describe ::ActivePublisher::Configuration do
     specify { expect(subject.port).to eq(5672) }
     specify { expect(subject.timeout).to eq(1) }
   end
+
+  it "logs errors with the default error handler" do
+    error = ::RuntimeError.new("ohai")
+    expect(::ActivePublisher::Logging.logger).to receive(:error).with(::RuntimeError)
+    expect(::ActivePublisher::Logging.logger).to receive(:error).with(error.message)
+
+    ::ActivePublisher.configuration.error_handler.call(error, {})
+  end
 end


### PR DESCRIPTION
This adds a configurable `error_handler` so client code can forward errors to however they want (honeybadger, logging, etc).

I think this the last feature that I really wanted to get in before cutting a first `0.1.0` version.

/cc @film42 @liveh2o @andrew-lewin 
