### PR TITLE
fire load hooks when the gem is finished loading

### DIFF
--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -63,6 +63,10 @@ module ActivePublisher
   end
 end
 
+if defined?(::ActiveSupport)
+  ::ActiveSupport.run_load_hooks(:active_publisher)
+end
+
 at_exit do
   ::ActivePublisher::Async.publisher_adapter.shutdown! if ::ActivePublisher::Async.publisher_adapter
   ::ActivePublisher::Connection.disconnect!


### PR DESCRIPTION
We don't have any dependency on `ActiveSupport`, but I think it would be a good idea for us to fire an `ActiveSupport` load hook when this gem loads (if the current project is using ActiveSupport). This makes it very easy for our `buttress` gem to setup some defaults for publishing on all of our rails apps.

/cc @film42 @andrew-lewin 
