### PR TITLE
fix configure_from_yaml_and_cli

### DIFF
--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -45,8 +45,8 @@ module ActivePublisher
 
           yaml_config = attempt_to_load_yaml_file(env)
           DEFAULTS.each_pair do |key, value|
-            setting = cli_options[key] || yaml_config[key.to_s]
-            ::ActivePublisher.config.__send__("#{key}=", setting) if setting
+            setting = cli_options[key] || cli_options[key.to_s] || yaml_config[key] || yaml_config[key.to_s]
+            ::ActivePublisher.configuration.public_send("#{key}=", setting) if setting
           end
 
           true
@@ -60,7 +60,7 @@ module ActivePublisher
     def self.attempt_to_load_yaml_file(env)
       yaml_config = {}
       absolute_config_path = ::File.expand_path(::File.join("config", "active_publisher.yml"))
-        action_subscriber_config_file = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
+      action_subscriber_config_file = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
       if ::File.exists?(absolute_config_path)
         yaml_config = ::YAML.load_file(absolute_config_path)[env]
       elsif ::File.exists?(action_subscriber_config_file)

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -14,4 +14,16 @@ describe ::ActivePublisher::Configuration do
 
     ::ActivePublisher.configuration.error_handler.call(error, {})
   end
+
+  describe ".configure_from_yaml_and_cli" do
+    it "sets configuration values on the shared configuration object" do
+      expect(::ActivePublisher.configuration).to receive(:password=).with("WAT").and_return(true)
+      ::ActivePublisher::Configuration.configure_from_yaml_and_cli({:password => "WAT"}, true)
+    end
+
+    it "looks for string keys as well" do
+      expect(::ActivePublisher.configuration).to receive(:password=).with("WAT").and_return(true)
+      ::ActivePublisher::Configuration.configure_from_yaml_and_cli({"password" => "WAT"}, true)
+    end
+  end
 end


### PR DESCRIPTION
We were calling `config` instead of `configuration` and we also had some gotchas with how we looked for keys in the CLI config and YAML config. I've added tests around these things and also used this to do some smoke tests on the `configure_from_yaml_and_cli`.

This is another gotcha that I found when trying to make use of this library in a production rails app.

/cc @film42 @andrew-lewin @liveh2o 
