### PR TITLE
allow a frozen hash of publishing options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
  - 2.1
  - 2.2
  - jruby-1.7
- - jruby-9.0.4.0
+ - jruby-9.1.0.0
  - jruby-head
 services:
  - rabbitmq

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -33,11 +33,13 @@ module ActivePublisher
     end
   end
 
-  def self.publishing_options(route, options = {})
-    options[:mandatory] = false unless options.key(:mandatory)
-    options[:persistent] = false unless options.key(:persistent)
-    options[:routing_key] = route
-
+  def self.publishing_options(route, in_options = {})
+    options = {
+      :mandatory => false,
+      :persistent => false,
+      :routing_key => route,
+    }.merge(in_options)
+    
     if ::RUBY_PLATFORM == "java"
       java_options = {}
       java_options[:mandatory]   = options.delete(:mandatory)

--- a/spec/lib/active_publisher_spec.rb
+++ b/spec/lib/active_publisher_spec.rb
@@ -1,4 +1,5 @@
 describe ::ActivePublisher do
+  PUBLISH_OPTIONS = {:persistent => true}.freeze
   let(:exchange) { double("Rabbit Exchange") }
   let(:exchange_name) { "events" }
   let(:payload) { "Yo Dawg" }
@@ -13,21 +14,21 @@ describe ::ActivePublisher do
           expect(published_payload).to eq(payload)
           expect(published_options[:routing_key]).to eq(route)
           expect(published_options[:mandatory]).to eq(false)
-          expect(published_options[:properties][:persistent]).to eq(false)
+          expect(published_options[:properties][:persistent]).to eq(true)
         end
 
-        described_class.publish(route, payload, exchange_name)
+        described_class.publish(route, payload, exchange_name, PUBLISH_OPTIONS)
       end
     else
       it "publishes to the exchange with default options for bunny" do
         expect(exchange).to receive(:publish) do |published_payload, published_options|
           expect(published_payload).to eq(payload)
           expect(published_options[:routing_key]).to eq(route)
-          expect(published_options[:persistent]).to eq(false)
+          expect(published_options[:persistent]).to eq(true)
           expect(published_options[:mandatory]).to eq(false)
         end
 
-        described_class.publish(route, payload, exchange_name)
+        described_class.publish(route, payload, exchange_name, PUBLISH_OPTIONS)
       end
     end
   end


### PR DESCRIPTION
One of our applications started throwing errors because it passes in a frozen hash of publishing options.

```
E, [2016-05-09T10:37:42.535000 #23948] ERROR -- : RuntimeError
E, [2016-05-09T10:37:42.536000 #23948] ERROR -- : can't modify frozen Hash
E, [2016-05-09T10:37:42.536000 #23948] ERROR -- : org/jruby/RubyHash.java:1005:in `[]='
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher.rb:37:in `publishing_options'
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher.rb:32:in `block in publish'
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher.rb:58:in `with_exchange'
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher.rb:31:in `publish'
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher/async/in_memory_adapter.rb:109:in `block in create_consumer'
org/jruby/RubyKernel.java:1291:in `loop'
/srv/grunt/shared/bundle/jruby/2.2.0/gems/active_publisher-0.1.4-java/lib/active_publisher/async/in_memory_adapter.rb:104:in `block in create_consumer'
```

This adds a test case and uses `merge` to create the publishing options rather than trying to modify the provided hash.

/cc @abrandoned @brianstien @liveh2o
