### PR TITLE
Abrandoned/bulk publish api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-*
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -14,6 +14,8 @@ require "active_publisher/configuration"
 require "active_publisher/connection"
 
 module ActivePublisher
+  class UnknownMessageClassError < StandardError; end
+
   def self.configuration
     @configuration ||= ::ActivePublisher::Configuration.new
   end
@@ -37,7 +39,7 @@ module ActivePublisher
   def self.publish_all(exchange_name, messages)
     with_exchange(exchange_name) do |exchange|
       messages.each do |message|
-        raise "bulk publishing messages must be of type ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
+        fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
         exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
       end
     end

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -8,6 +8,7 @@ require "thread"
 require "active_publisher/logging"
 require "active_publisher/async"
 require "active_publisher/async/in_memory_adapter"
+require "active_publisher/message"
 require "active_publisher/version"
 require "active_publisher/configuration"
 require "active_publisher/connection"
@@ -30,6 +31,15 @@ module ActivePublisher
   def self.publish(route, payload, exchange_name, options = {})
     with_exchange(exchange_name) do |exchange|
       exchange.publish(payload, publishing_options(route, options))
+    end
+  end
+
+  def self.publish_all(exchange_name, messages)
+    with_exchange(exchange_name) do |exchange|
+      messages.each do |message|
+        raise "bulk publishing messages must be of type ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
+        exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
+      end
     end
   end
 

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -5,6 +5,11 @@ require "active_publisher/async/in_memory_adapter/consumer_thread"
 module ActivePublisher
   module Async
     module InMemoryAdapter
+
+      def self.new(*args)
+        ::ActivePublisher::Async::InMemoryAdapter::Adapter.new(*args)
+      end
+
       class UnableToPersistMessageError < ::StandardError; end
 
       class Adapter

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -1,148 +1,48 @@
+require "active_publisher/message"
+require "active_publisher/async/in_memory_adapter/async_queue"
+require "active_publisher/async/in_memory_adapter/consumer_thread"
+
 module ActivePublisher
   module Async
-    class InMemoryAdapter
-      include ::ActivePublisher::Logging
+    module InMemoryAdapter
+      class UnableToPersistMessageError < ::StandardError; end
 
-      attr_reader :async_queue
-
-      def initialize(drop_messages_when_queue_full = false, max_queue_size = 1_000_000, supervisor_interval = 0.2)
-        logger.info "Starting in-memory publisher adapter"
-
-        @async_queue = ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(
-          drop_messages_when_queue_full,
-          max_queue_size,
-          supervisor_interval
-        )
-      end
-
-      def publish(route, payload, exchange_name, options = {})
-        message = ::ActivePublisher::Async::InMemoryAdapter::Message.new(route, payload, exchange_name, options)
-        async_queue.push(message)
-        nil
-      end
-
-      def shutdown!
-        max_wait_time = ::ActivePublisher.configuration.seconds_to_wait_for_graceful_shutdown
-        started_shutting_down_at = ::Time.now
-
-        logger.info "Draining async publisher in-memory adapter queue before shutdown. current queue size: #{async_queue.size}."
-        while async_queue.size > 0
-          if (::Time.now - started_shutting_down_at) > max_wait_time
-            logger.info "Forcing async publisher adapter shutdown because graceful shutdown period of #{max_wait_time} seconds was exceeded. Current queue size: #{async_queue.size}."
-            break
-          end
-
-          sleep 0.1
-        end
-      end
-
-      class AsyncQueue
+      class Adapter
         include ::ActivePublisher::Logging
 
-        attr_accessor :drop_messages_when_queue_full,
-                      :max_queue_size,
-                      :supervisor_interval
+        attr_reader :async_queue
 
-        attr_reader :consumer, :queue, :supervisor
+        def initialize(drop_messages_when_queue_full = false, max_queue_size = 1_000_000, supervisor_interval = 0.2)
+          logger.info "Starting in-memory publisher adapter"
 
-        if ::RUBY_PLATFORM == "java"
-          NETWORK_ERRORS = [::MarchHare::Exception, ::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException].freeze
-        else
-          NETWORK_ERRORS = [::Bunny::Exception, ::Timeout::Error, ::IOError].freeze
+          @async_queue = ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(
+            drop_messages_when_queue_full,
+            max_queue_size,
+            supervisor_interval
+          )
         end
 
-        def initialize(drop_messages_when_queue_full, max_queue_size, supervisor_interval)
-          @drop_messages_when_queue_full = drop_messages_when_queue_full
-          @max_queue_size = max_queue_size
-          @supervisor_interval = supervisor_interval
-          @queue = ::Queue.new
-          create_and_supervise_consumer!
+        def publish(route, payload, exchange_name, options = {})
+          message = ::ActivePublisher::Message.new(route, payload, exchange_name, options)
+          async_queue.push(message)
+          nil
         end
 
-        def push(message)
-          # default of 1_000_000 messages
-          if queue.size > max_queue_size
-            # Drop messages if the queue is full and we were configured to do so
-            return if drop_messages_when_queue_full
+        def shutdown!
+          max_wait_time = ::ActivePublisher.configuration.seconds_to_wait_for_graceful_shutdown
+          started_shutting_down_at = ::Time.now
 
-            # By default we will raise an error to push the responsibility onto the caller
-            fail ::ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError, "Queue is full, messages will be dropped."
-          end
-
-          queue.push(message)
-        end
-
-        def size
-          queue.size
-        end
-
-      private
-
-        def await_network_reconnect
-          sleep ::ActivePublisher::RabbitConnection::NETWORK_RECOVERY_INTERVAL
-        end
-
-        def create_and_supervise_consumer!
-          @consumer = create_consumer
-          @supervisor = ::Thread.new do
-            loop do
-              unless consumer.alive?
-                # We might need to requeue the last message.
-                queue.push(@current_message) unless @current_message.nil?
-                consumer.kill
-                @consumer = create_consumer
-              end
-
-              # Pause before checking the consumer again.
-              sleep supervisor_interval
+          logger.info "Draining async publisher in-memory adapter queue before shutdown. current queue size: #{async_queue.size}."
+          while async_queue.size > 0
+            if (::Time.now - started_shutting_down_at) > max_wait_time
+              logger.info "Forcing async publisher adapter shutdown because graceful shutdown period of #{max_wait_time} seconds was exceeded. Current queue size: #{async_queue.size}."
+              break
             end
+
+            sleep 0.1
           end
         end
 
-        def create_consumer
-          ::Thread.new do
-            loop do
-              # Write "current_message" so we can requeue should something happen to the consumer.
-              @current_message = message = queue.pop
-
-              begin
-                ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
-
-                # Reset
-                @current_message = nil
-              rescue *NETWORK_ERRORS
-                # Sleep because connection is down
-                await_network_reconnect
-
-                # Requeue and try again.
-                queue.push(message)
-              rescue => unknown_error
-                # Do not requeue the message because something else horrible happened.
-                @current_message = nil
-
-                ::ActivePublisher.configuration.error_handler.call(unknown_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
-
-                # TODO: Find a way to bubble this out of the thread for logging purposes.
-                # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
-                raise unknown_error
-              end
-            end
-          end
-        end
-      end
-
-      class Message
-        attr_reader :route, :payload, :exchange_name, :options
-
-        def initialize(route, payload, exchange_name, options)
-          @route = route
-          @payload = payload
-          @exchange_name = exchange_name
-          @options = options
-        end
-      end
-
-      class UnableToPersistMessageError < ::StandardError
       end
     end
   end

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -1,0 +1,65 @@
+module ActivePublisher
+  module Async
+    module InMemoryAdapter
+      class AsyncQueue
+        include ::ActivePublisher::Logging
+
+        attr_accessor :drop_messages_when_queue_full,
+          :max_queue_size,
+          :supervisor_interval
+
+        attr_reader :consumer, :queue, :supervisor
+
+        def initialize(drop_messages_when_queue_full, max_queue_size, supervisor_interval)
+          @drop_messages_when_queue_full = drop_messages_when_queue_full
+          @max_queue_size = max_queue_size
+          @supervisor_interval = supervisor_interval
+          @queue = ::Queue.new
+          create_and_supervise_consumer!
+        end
+
+        def push(message)
+          # default of 1_000_000 messages
+          if queue.size > max_queue_size
+            # Drop messages if the queue is full and we were configured to do so
+            return if drop_messages_when_queue_full
+
+            # By default we will raise an error to push the responsibility onto the caller
+            fail ::ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError, "Queue is full, messages will be dropped."
+          end
+
+          queue.push(message)
+        end
+
+        def size
+          queue.size
+        end
+
+        private
+
+        def create_and_supervise_consumer!
+          @consumer = create_consumer
+          @supervisor = ::Thread.new do
+            loop do
+              unless consumer.alive?
+                # We might need to requeue the last message.
+                consumer_current_message = consumer.current_message
+                queue.push(consumer_current_message) if consumer_current_message
+                consumer.kill
+                @consumer = create_consumer
+              end
+
+              # Pause before checking the consumer again.
+              sleep supervisor_interval
+            end
+          end
+        end
+
+        def create_consumer
+          ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -42,9 +42,11 @@ module ActivePublisher
           @supervisor = ::Thread.new do
             loop do
               unless consumer.alive?
-                # We might need to requeue the last message.
-                consumer_current_message = consumer.current_message
-                queue.push(consumer_current_message) if consumer_current_message
+                # We might need to requeue the last messages popped
+                consumer.current_messages.each do |current_message|
+                  queue.push(current_message)
+                end
+
                 consumer.kill
                 @consumer = ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
               end

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -38,7 +38,7 @@ module ActivePublisher
         private
 
         def create_and_supervise_consumer!
-          @consumer = create_consumer
+          @consumer = ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
           @supervisor = ::Thread.new do
             loop do
               unless consumer.alive?
@@ -46,17 +46,13 @@ module ActivePublisher
                 consumer_current_message = consumer.current_message
                 queue.push(consumer_current_message) if consumer_current_message
                 consumer.kill
-                @consumer = create_consumer
+                @consumer = ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
               end
 
               # Pause before checking the consumer again.
               sleep supervisor_interval
             end
           end
-        end
-
-        def create_consumer
-          ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
         end
       end
 

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -1,4 +1,4 @@
-require 'pry'
+
 module ActivePublisher
   module Async
     module InMemoryAdapter
@@ -28,7 +28,11 @@ module ActivePublisher
         private
 
         def await_network_reconnect
-          sleep ::ActivePublisher::RabbitConnection::NETWORK_RECOVERY_INTERVAL
+          if defined?(ActivePublisher::RabbitConnection)
+            sleep ::ActivePublisher::RabbitConnection::NETWORK_RECOVERY_INTERVAL
+          else
+            sleep 0.1
+          end
         end
 
         def start_thread

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -1,0 +1,68 @@
+require 'pry'
+module ActivePublisher
+  module Async
+    module InMemoryAdapter
+      class ConsumerThread
+        attr_reader :current_message, :thread, :queue
+
+        if ::RUBY_PLATFORM == "java"
+          NETWORK_ERRORS = [::MarchHare::Exception, ::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException].freeze
+        else
+          NETWORK_ERRORS = [::Bunny::Exception, ::Timeout::Error, ::IOError].freeze
+        end
+
+        def initialize(listen_queue)
+          @queue = listen_queue
+          start_thread
+        end
+
+        def alive?
+          @thread && @thread.alive?
+        end
+
+        def kill
+          @thread.kill if @thread
+          @thread = nil
+        end
+
+        private
+
+        def await_network_reconnect
+          sleep ::ActivePublisher::RabbitConnection::NETWORK_RECOVERY_INTERVAL
+        end
+
+        def start_thread
+          return if alive?
+          @thread = ::Thread.new do
+            loop do
+              # Write "current_message" so we can requeue should something happen to the consumer.
+              @current_message = message = queue.pop
+
+              begin
+                ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
+
+                # Reset
+                @current_message = nil
+              rescue *NETWORK_ERRORS
+                # Sleep because connection is down
+                await_network_reconnect
+
+                # Requeue and try again.
+                queue.push(@current_message) if @current_message
+              rescue => unknown_error
+                # Do not requeue the message because something else horrible happened.
+                @current_message = nil
+
+                ::ActivePublisher.configuration.error_handler.call(unknown_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
+
+                # TODO: Find a way to bubble this out of the thread for logging purposes.
+                # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
+                raise unknown_error
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_publisher/message.rb
+++ b/lib/active_publisher/message.rb
@@ -1,0 +1,3 @@
+module ActivePublisher
+  class Message < Struct.new(:route, :payload, :exchange_name, :options); end
+end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -40,11 +40,6 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
     end
 
     describe "#create_and_supervise_consumer!" do
-      it "creates a supervisor" do
-        expect_any_instance_of(ActivePublisher::Async::InMemoryAdapter::AsyncQueue).to receive(:create_consumer)
-        subject
-      end
-
       it "restarts the consumer when it dies" do
         consumer = subject.consumer
         consumer.kill
@@ -67,7 +62,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       end
 
       context "when network error occurs" do
-        let(:error) { ActivePublisher::Async::InMemoryAdapter::AsyncQueue::NETWORK_ERRORS.first }
+        let(:error) { ActivePublisher::Async::InMemoryAdapter::ConsumerThread::NETWORK_ERRORS.first }
         before { allow(::ActivePublisher).to receive(:publish).and_raise(error) }
 
         it "requeues the message" do
@@ -96,7 +91,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       after { subject.drop_messages_when_queue_full = false }
 
       context "when the queue has room" do
-        before { allow(::Queue).to receive(:new).and_return(mock_queue) }
+        before { allow(Queue).to receive(:new).and_return(mock_queue) }
 
         it "successfully adds to the queue" do
           expect(mock_queue).to receive(:push).with(message)

--- a/spec/lib/active_publisher/async_spec.rb
+++ b/spec/lib/active_publisher/async_spec.rb
@@ -1,6 +1,6 @@
 describe ::ActivePublisher::Async do
   before { described_class.instance_variable_set(:@publisher_adapter, nil) }
-  after { ::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter.new }
+  after { ::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter::Adapter.new }
 
   let(:mock_adapter) { double(:publish => nil) }
 
@@ -14,10 +14,10 @@ describe ::ActivePublisher::Async do
   end
 
   context "when an in-memory adapter is selected" do
-    before { ::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter.new }
+    before { ::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter::Adapter.new }
 
     it "Creates an in-memory publisher" do
-      expect(described_class.publisher_adapter).to be_an(::ActivePublisher::Async::InMemoryAdapter)
+      expect(described_class.publisher_adapter).to be_an(::ActivePublisher::Async::InMemoryAdapter::Adapter)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "active_publisher"
 require "support/setup_subscriber"
 
-::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter.new
-
+::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter::Adapter.new
+::Thread.abort_on_exception = true
 # Silence the logger
 $TESTING = true
 ::ActivePublisher::Logging.initialize_logger(nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require "active_publisher"
 require "support/setup_subscriber"
 
 ::ActivePublisher::Async.publisher_adapter = ::ActivePublisher::Async::InMemoryAdapter::Adapter.new
-::Thread.abort_on_exception = true
 # Silence the logger
 $TESTING = true
 ::ActivePublisher::Logging.initialize_logger(nil)


### PR DESCRIPTION
Nothing being done to address the issue that I put in #21 
but this is a refactor that keeps the current functionality while making room for additional adapters and a bulk interface that we can use to help address the issue

Refactoring for a multi-adapter and/or multi-pop future of active_publisher

1. split out the classes to make them a little easier to reason over
2. added a bulk publish endpoint to Publisher that may be used in the future
3. changed to `current_messages` interface over `current_message` to prepare for multiple publish interface
4. elevated Message to a first class object in the lib that can be used by other adapters

@quixoten @film42 @mmmries 