### PR TITLE
add publish_all specs and use multiopqueue with concat/pop_up_to and 20

### DIFF
--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'bunny', '~> 2.1'
   end
 
-  spec.add_dependency 'multi_op_queue'
+  spec.add_dependency 'multi_op_queue', '>= 0.1.2'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'bunny', '~> 2.1'
   end
 
+  spec.add_dependency 'multi_op_queue'
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -15,6 +15,7 @@ require "active_publisher/connection"
 
 module ActivePublisher
   class UnknownMessageClassError < StandardError; end
+  class ExchangeMismatchError < StandardError; end
 
   def self.configuration
     @configuration ||= ::ActivePublisher::Configuration.new
@@ -40,6 +41,7 @@ module ActivePublisher
     with_exchange(exchange_name) do |exchange|
       messages.each do |message|
         fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
+        fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
         exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
       end
     end

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -1,6 +1,7 @@
 require "active_publisher/message"
 require "active_publisher/async/in_memory_adapter/async_queue"
 require "active_publisher/async/in_memory_adapter/consumer_thread"
+require "multi_op_queue"
 
 module ActivePublisher
   module Async

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -1,4 +1,3 @@
-
 module ActivePublisher
   module Async
     module InMemoryAdapter
@@ -41,10 +40,13 @@ module ActivePublisher
           @thread = ::Thread.new do
             loop do
               # Write "current_messages" so we can requeue should something happen to the consumer.
-              @current_messages << message = queue.pop
+              @current_messages.concat(queue.pop_up_to(20))
 
               begin
-                ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
+                # Only open a single connection for each group of messages to an exchange
+                @current_messages.group_by(&:exchange_name).each do |exchange_name, messages|
+                  ::ActivePublisher.publish_all(exchange_name, messages)
+                end
 
                 # Reset
                 @current_messages = []
@@ -53,14 +55,19 @@ module ActivePublisher
                 await_network_reconnect
 
                 # Requeue and try again.
-                @current_messages.each do |current_message|
-                  queue.push(current_message)
-                end
+                queue.concat(@current_messages) unless @current_messages.empty?
               rescue => unknown_error
+                @current_messages.each do |message|
+                  # Degrade to single message publish ... or at least attempt to
+                  begin
+                    ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
+                  rescue => error
+                    ::ActivePublisher.configuration.error_handler.call(unknown_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
+                  end
+                end
+
                 # Do not requeue the message because something else horrible happened.
                 @current_messages = []
-
-                ::ActivePublisher.configuration.error_handler.call(unknown_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
 
                 # TODO: Find a way to bubble this out of the thread for logging purposes.
                 # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.

--- a/lib/active_publisher/connection.rb
+++ b/lib/active_publisher/connection.rb
@@ -24,6 +24,8 @@ module ActivePublisher
 
         @connection = nil
       end
+    rescue Timeout::Error
+      # No-op ... this happens sometimes on MRI disconnect
     end
 
     # Private API

--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "0.1.5"
+  VERSION = "0.2.0.pre"
 end


### PR DESCRIPTION
a first simple cut add addressing #21 

using the multi_op_queue (to remove locking multiple times for a bulk pop) and utilizing the `publish_all` interface to pull off "up to" 20 messages and publish to rabbit with ideally a single connection

instead of using a multiple thread mechanism I thought the simplest attempt would be to use multiple operations per lock when the queue has many items and publish them over a single connection, the only difference is the per-message error capture and retry which I attempted to handle via degrading to a single message publish if an unknown error occurs

a future iteration could make the pop size configurable but didn't want to over-optimize on first cut

thoughts?

@film42 @quixoten @mmmries 