### PR TITLE
Ensure message queue does not grow unbounded; Fix queue size

### DIFF
--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "0.2.0"
+  VERSION = "0.2.1-pre1"
 end


### PR DESCRIPTION
Yet another attempt at fixing https://github.com/mxenabled/active_publisher/issues/25

1. This removes the `@current_messages` instance variable, because we don't need it.
2. This ensures published messages are removed `current_messages` and unsuccessful messages are appended on failure.
3. This fixes the queue size to be either the queue before we pop'd during the current publish loop, or the actual queue size (whichever is bigger). This is to ensure we don't shutdown when messages have been pop'd but not yet published.

cc @abrandoned @mmmries @liveh2o @brianstien 