### PR TITLE
Allow TLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ Defaults for the configuration are:
   :heartbeat => 5,
   :host => "localhost",
   :hosts => [],
+  :password => "guest",
   :port => 5672,
   :publisher_confirms => false,
   :seconds_to_wait_for_graceful_shutdown => 30,
   :timeout => 1,
+  :tls => false,
+  :tls_ca_certificates => [],
+  :tls_cert => nil,
+  :tls_key => nil,
   :username => "guest",
-  :password => "guest",
+  :verify_peer => true,
   :virtual_host => "/"
 }
 ```

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -10,8 +10,13 @@ module ActivePublisher
                   :port,
                   :publisher_confirms,
                   :seconds_to_wait_for_graceful_shutdown,
-                  :username,
                   :timeout,
+                  :tls,
+                  :tls_ca_certificates,
+                  :tls_cert,
+                  :tls_key,
+                  :username,
+                  :verify_peer,
                   :virtual_host
 
     CONFIGURATION_MUTEX = ::Mutex.new
@@ -25,12 +30,17 @@ module ActivePublisher
       :heartbeat => 5,
       :host => "localhost",
       :hosts => [],
+      :password => "guest",
       :port => 5672,
       :publisher_confirms => false,
       :seconds_to_wait_for_graceful_shutdown => 30,
       :timeout => 1,
+      :tls => false,
+      :tls_ca_certificates => [],
+      :tls_cert => nil,
+      :tls_key => nil,
       :username => "guest",
-      :password => "guest",
+      :verify_peer => true,
       :virtual_host => "/"
     }
 

--- a/lib/active_publisher/connection.rb
+++ b/lib/active_publisher/connection.rb
@@ -42,15 +42,20 @@ module ActivePublisher
 
     def self.connection_options
       {
+        :automatically_recover         => true,
+        :continuation_timeout          => ::ActivePublisher.configuration.timeout * 1_000.0, #convert sec to ms
         :heartbeat                     => ::ActivePublisher.configuration.heartbeat,
         :hosts                         => ::ActivePublisher.configuration.hosts,
+        :network_recovery_interval     => NETWORK_RECOVERY_INTERVAL,
         :pass                          => ::ActivePublisher.configuration.password,
         :port                          => ::ActivePublisher.configuration.port,
-        :user                          => ::ActivePublisher.configuration.username,
-        :continuation_timeout          => ::ActivePublisher.configuration.timeout * 1_000.0, #convert sec to ms
-        :automatically_recover         => true,
-        :network_recovery_interval     => NETWORK_RECOVERY_INTERVAL,
         :recover_from_connection_close => true,
+        :tls                           => ::ActivePublisher.configuration.tls,
+        :tls_ca_certificates           => ::ActivePublisher.configuration.tls_ca_certificates,
+        :tls_cert                      => ::ActivePublisher.configuration.tls_cert,
+        :tls_key                       => ::ActivePublisher.configuration.tls_key,
+        :user                          => ::ActivePublisher.configuration.username,
+        :verify_peer                   => ::ActivePublisher.configuration.verify_peer,
       }
     end
     private_class_method :connection_options

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -5,6 +5,7 @@ describe ::ActivePublisher::Configuration do
     specify { expect(subject.hosts).to eq(["localhost"]) }
     specify { expect(subject.port).to eq(5672) }
     specify { expect(subject.timeout).to eq(1) }
+    specify { expect(subject.tls).to eq(false) }
   end
 
   it "logs errors with the default error handler" do


### PR DESCRIPTION
This does the same thing as mxenabled/action_subscriber/pull/79... it allows TLS configuration options to be passed to bunny and march_hare.

@mmmries @abrandoned @film42 @liveh2o 