### PR TITLE
Reuse channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: ruby
 rvm:
- - 2.0
- - 2.1
  - 2.2
+ - 2.3
+ - 2.4
  - jruby-1.7
- - jruby-9.1.0.0
- - jruby-head
+ - jruby-9.1.12.0
 services:
  - rabbitmq
 sudo: false
 cache: bundler
-matrix:
-  allow_failures:
-    - rvm: jruby-head

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -16,6 +16,7 @@ require "active_publisher/connection"
 module ActivePublisher
   class UnknownMessageClassError < StandardError; end
   class ExchangeMismatchError < StandardError; end
+  class FailedPublisherConfirms < StandardError; end
 
   def self.configuration
     @configuration ||= ::ActivePublisher::Configuration.new
@@ -62,7 +63,7 @@ module ActivePublisher
       :persistent => false,
       :routing_key => route,
     }.merge(in_options)
-    
+
     if ::RUBY_PLATFORM == "java"
       java_options = {}
       java_options[:mandatory]   = options.delete(:mandatory)

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -104,14 +104,19 @@ module ActivePublisher
               raise
             end
           end
-          if channel.using_publisher_confirms?
-            begin
-              channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
-            rescue
-              messages.concat(potentially_retry)
-              raise
-            end
+          wait_for_confirms(channel, messages, potentially_retry)
+        end
+
+        def wait_for_confirms(channel, messages, potentially_retry)
+          return true unless channel.using_publisher_confirms?
+          if channel.method(:wait_for_confirms).arity > 0
+            channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
+          else
+            channel.wait_for_confirms
           end
+        rescue
+          messages.concat(potentially_retry)
+          raise
         end
       end
     end

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -104,7 +104,7 @@ module ActivePublisher
               raise
             end
           end
-          if channel.uses_publisher_confirms?
+          if channel.using_publisher_confirms?
             begin
               channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
             rescue

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -9,6 +9,7 @@ module ActivePublisher
                   :password,
                   :port,
                   :publisher_confirms,
+                  :publisher_confirms_timeout,
                   :seconds_to_wait_for_graceful_shutdown,
                   :timeout,
                   :tls,
@@ -33,6 +34,7 @@ module ActivePublisher
       :password => "guest",
       :port => 5672,
       :publisher_confirms => false,
+      :publisher_confirms_timeout => 5_000, #specified as a number of milliseconds
       :seconds_to_wait_for_graceful_shutdown => 30,
       :timeout => 1,
       :tls => false,

--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "0.3.0"
+  VERSION = "0.4.0.pre1"
 end


### PR DESCRIPTION
__The Problem__

During our rabbitmq consultation with ErlangSolutions one of the tests we performed was to compare the difference between publishers that create/destroy a channel for each publish vs those that attempt to re-use a channel as much as a possible. [In my test](https://gitlab.mx.com/dev/io/issues/277#note_217410) I found that creating/destroying a channel on every publish increased CPU by ~20% and that was only publishing ~300 messages per second.

In production we are publishing ~300-600 messages/sec across the platform during relatively calm periods (just background agg) and those are all creating/destroying channels which may account for our high CPU usage.

__This Solution__

This branch attempts to create and memoize a channel in the consumer thread. The channel is re-used for all subsequent publishes with the same begins and rescues that we already have in place. I tested force closing a connection from the broker, doing graceful restarts from the broker and doing `kill -9` on the broker during publishing. I found that with publisher confirms disabled some messages were lost in these failure scenarios and with publisher confirms enabled some messages were double-published during these failure scenarios. This keeps with our current behavior under these same failure scenarios.

I also increased the batch size for grabbing things off the queue from 20 -> 50. In my testing this improved publishing throughput from ~800/sec to ~1800/sec when you have publisher confirms turned on. I also added a configurable `publisher_confirms_timeout` and use that when waiting for confirms to avoid blocking indefinitely.

/cc @abrandoned @film42 