### PR TITLE
Back pressure strategies + lower default queue size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
- - 2.2
  - 2.3
  - 2.4
- - jruby-1.7
  - jruby-9.1.12.0
 services:
  - rabbitmq

--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'bunny', '~> 2.1'
   end
 
+  spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'multi_op_queue', '>= 0.1.2'
 
   spec.add_development_dependency "bundler"

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -35,7 +35,9 @@ module ActivePublisher
   # @param [Hash] options hash to set message parameters (e.g. headers)
   def self.publish(route, payload, exchange_name, options = {})
     with_exchange(exchange_name) do |exchange|
-      exchange.publish(payload, publishing_options(route, options))
+      ::ActiveSupport::Notifications.instrument "message_published.active_publisher" do
+        exchange.publish(payload, publishing_options(route, options))
+      end
     end
   end
 
@@ -49,7 +51,9 @@ module ActivePublisher
         fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
 
         begin
-          exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
+          ::ActiveSupport::Notifications.instrument "message_published.active_publisher" do
+            exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
+          end
         rescue
           messages << message
           raise

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -3,6 +3,7 @@ if ::RUBY_PLATFORM == "java"
 else
   require "bunny"
 end
+require "active_support"
 require "thread"
 
 require "active_publisher/logging"

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -18,11 +18,11 @@ module ActivePublisher
 
         attr_reader :async_queue
 
-        def initialize(drop_messages_when_queue_full = false, max_queue_size = 1_000_000, supervisor_interval = 0.2)
+        def initialize(back_pressure_strategy = :raise, max_queue_size = 1_000_000, supervisor_interval = 0.2)
           logger.info "Starting in-memory publisher adapter"
 
           @async_queue = ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(
-            drop_messages_when_queue_full,
+            back_pressure_strategy,
             max_queue_size,
             supervisor_interval
           )

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -18,7 +18,7 @@ module ActivePublisher
 
         attr_reader :async_queue
 
-        def initialize(back_pressure_strategy = :raise, max_queue_size = 1_000_000, supervisor_interval = 0.2)
+        def initialize(back_pressure_strategy = :raise, max_queue_size = 100_000, supervisor_interval = 0.2)
           logger.info "Starting in-memory publisher adapter"
 
           @async_queue = ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -37,8 +37,10 @@ module ActivePublisher
             when :raise
               fail ::ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError, "Queue is full, messages will be dropped."
             when :wait
-              # This is a really crappy way to wait
-              sleep 0.01 until queue.size < max_queue_size
+              ::ActiveSupport::Notifications.instrument "wait_for_async_queue.active_publisher" do
+                # This is a really crappy way to wait
+                sleep 0.01 until queue.size < max_queue_size
+              end
             end
           end
 

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -67,7 +67,7 @@ module ActivePublisher
                 @consumer = ::ActivePublisher::Async::InMemoryAdapter::ConsumerThread.new(queue)
               end
 
-              # Notify the current queue size
+              # Notify the current queue size.
               ::ActiveSupport::Notifications.instrument "async_queue_size.active_publisher", queue.size
 
               # Pause before checking the consumer again.

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -86,7 +86,7 @@ module ActivePublisher
         end
 
         def publish_all(channel, exchange_name, messages)
-          ::ActiveSupport::Notifications.instrument "message_batch_published.active_publisher", :message_count => messages.size do
+          ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :message_count => messages.size do
             exchange = channel.topic(exchange_name)
             potentially_retry = []
             loop do

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -86,25 +86,27 @@ module ActivePublisher
         end
 
         def publish_all(channel, exchange_name, messages)
-          exchange = channel.topic(exchange_name)
-          potentially_retry = []
-          loop do
-            break if messages.empty?
-            message = messages.shift
+          ::ActiveSupport::Notifications.instrument "message_batch_published.active_publisher", :message_count => messages.size do
+            exchange = channel.topic(exchange_name)
+            potentially_retry = []
+            loop do
+              break if messages.empty?
+              message = messages.shift
 
-            fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
-            fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
+              fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
+              fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
 
-            begin
-              options = ::ActivePublisher.publishing_options(message.route, message.options || {})
-              exchange.publish(message.payload, options)
-              potentially_retry << message
-            rescue
-              messages << message
-              raise
+              begin
+                options = ::ActivePublisher.publishing_options(message.route, message.options || {})
+                exchange.publish(message.payload, options)
+                potentially_retry << message
+              rescue
+                messages << message
+                raise
+              end
             end
+            wait_for_confirms(channel, messages, potentially_retry)
           end
-          wait_for_confirms(channel, messages, potentially_retry)
         end
 
         def wait_for_confirms(channel, messages, potentially_retry)

--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "1.0.0.pre3"
+  VERSION = "1.0.0.pre4"
 end

--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "0.4.0"
+  VERSION = "1.0.0.pre3"
 end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -6,6 +6,8 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
   let(:options) { { :test => :ok } }
   let(:message) { ActivePublisher::Message.new(route, payload, exchange_name, options) }
   let(:mock_queue) { double(:push => nil, :size => 0) }
+  let(:back_pressure_strategy) { :raise }
+  let(:max_queue_size) { 1_000_000 }
 
   describe "#publish" do
     before do
@@ -31,7 +33,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
   end
 
   describe "::AsyncQueue" do
-    subject { ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(false, 1_000_000, 0.2) }
+    subject { ActivePublisher::Async::InMemoryAdapter::AsyncQueue.new(back_pressure_strategy, max_queue_size, 0.2) }
 
     describe ".initialize" do
       it "creates a supervisor" do
@@ -86,9 +88,6 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
     end
 
     describe "#push" do
-      after { subject.max_queue_size = 1000 }
-      after { subject.drop_messages_when_queue_full = false }
-
       context "when the queue has room" do
         before { allow(::MultiOpQueue::Queue).to receive(:new).and_return(mock_queue) }
 
@@ -99,21 +98,41 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       end
 
       context "when the queue is full" do
-        before { subject.max_queue_size = -1 }
+        let(:max_queue_size) { -1 }
 
         context "and we're dropping messages" do
-          before { subject.drop_messages_when_queue_full = true }
+          let(:back_pressure_strategy) { :drop }
 
           it "adding to the queue should not raise an error" do
             expect { subject.push(message) }.to_not raise_error
           end
         end
 
-        context "and we're not dropping messages" do
-          before { subject.drop_messages_when_queue_full = false }
+        context "and we're waiting for space in the queue" do
+          let(:back_pressure_strategy) { :wait }
 
+          it "adding to the queue should not raise an error" do
+            expect(subject.queue).to receive(:push)
+            thread = Thread.new do
+              subject.push(message)
+            end
+            # Ensure the thread is waiting by doing a sleep here and checking thread.alive?
+            sleep 0.1
+            expect(thread).to be_alive
+            subject.max_queue_size = 100
+            thread.join
+          end
+        end
+
+        context "and we're raise errors" do
           it "adding to teh queue should raise error back to caller" do
             expect { subject.push(message) }.to raise_error(ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError)
+          end
+        end
+
+        context "invalid strategy" do
+          it "raises an error" do
+            expect { subject.back_pressure_strategy = :yolo }.to raise_error("Invalid back pressure strategy: yolo")
           end
         end
       end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -7,7 +7,23 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
   let(:message) { ActivePublisher::Message.new(route, payload, exchange_name, options) }
   let(:mock_queue) { double(:push => nil, :size => 0) }
   let(:back_pressure_strategy) { :raise }
-  let(:max_queue_size) { 1_000_000 }
+  let(:max_queue_size) { 100 }
+
+  describe ".new" do
+    context "defaults" do
+      it "sets a default max queue size" do
+        expect(subject.async_queue.max_queue_size).to eq(100_000)
+      end
+
+      it "sets a default back pressure strategy" do
+        expect(subject.async_queue.back_pressure_strategy).to eq(:raise)
+      end
+
+      it "sets a default supervisor interval" do
+        expect(subject.async_queue.supervisor_interval).to eq(0.2)
+      end
+    end
+  end
 
   describe "#publish" do
     before do

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -116,7 +116,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       context "when the queue is full" do
         let(:max_queue_size) { -1 }
 
-        context "and we're dropping messages" do
+        context "dropping messages" do
           let(:back_pressure_strategy) { :drop }
 
           it "adding to the queue should not raise an error" do
@@ -124,7 +124,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
           end
         end
 
-        context "and we're waiting for space in the queue" do
+        context "waiting for space in the queue" do
           let(:back_pressure_strategy) { :wait }
 
           it "adding to the queue should not raise an error" do
@@ -140,7 +140,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
           end
         end
 
-        context "and we're raise errors" do
+        context "raise errors" do
           it "adding to teh queue should raise error back to caller" do
             expect { subject.push(message) }.to raise_error(ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError)
           end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -74,7 +74,9 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
 
     describe "#create_consumer" do
       it "can successfully publish a message" do
-        expect(consumer).to receive(:publish_all).with(anything, exchange_name, [message])
+        expect(::ActiveSupport::Notifications).to receive(:instrument)
+                                                    .with("message_published.active_publisher",:message_count => 1)
+        expect(consumer).to receive(:publish_all).with(anything, exchange_name, [message]).and_call_original
         subject.push(message)
         sleep 0.1 # Await results
       end


### PR DESCRIPTION
This refactors the code to add a 3rd back pressure strategy. Here they are with new enums:
```
# These strategies are used to determine what to do with messages when the queue is full.
# :raise - Raise an error and drop the message.
# :drop - Silently drop the message.
# :wait - Wait for space in the queue to become available.
```
This default to `:raise`, so there shouldn't be a noticeable change for users who leave things default. If they did change the defaults, they'll get an error saying they're using an invalid strategy. They must be one of the 3 above. I thought about adding backward compat support for `true` and `false` considering this argument used to be a flag, but I'm already changing the API and figured it was better to be clear about the change being made. Thoughts here?

I also brought the default queue size limit down to 100K from 1M. Given our not so great experience with the queue size at 1M I figured it's better to set a safer limit in this lib.

cc @mmmries @liveh2o @brianstien @abrandoned @quixoten 