### PR TITLE
clarify configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ## Configuration
 
-ActivePublisher will use a `config/active_publisher.yml` or `config/action_subscriber.yml` automatically.
+ActivePublisher will use a `config/active_publisher.yml` or `config/action_subscriber.yml` if you include the line `::ActivePublisher::Configuration.configure_from_yaml_and_cli` in an initializer.
 
 Create a `config/active_publisher.yml` similar to a database.yml, with your configuration nested in your environments keys.
 


### PR DESCRIPTION
I've been setting up active_publisher and found that it wasn't automatically pulling in my `config/active_publisher.yml` or `config/action_subscriber.yml` settings.

It looks like on the `action_subscriber` side, we call the `::ActionSubscriber::Connection. configure_from_yaml_and_cli` while starting up the server https://github.com/mxenabled/action_subscriber/blob/master/bin/action_subscriber#L29, but nothing is calling that line on the `active_publisher` side.

@mmmries @film42 