### PR TITLE
allow the use of ERB in the yaml config file

### DIFF
--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -74,9 +74,9 @@ module ActivePublisher
       absolute_config_path = ::File.expand_path(::File.join("config", "active_publisher.yml"))
       action_subscriber_config_file = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
       if ::File.exists?(absolute_config_path)
-        yaml_config = ::YAML.load_file(absolute_config_path)[env]
+        yaml_config = ::YAML.load(::ERB.new(::File.read(absolute_config_path)).result)[env]
       elsif ::File.exists?(action_subscriber_config_file)
-        yaml_config = ::YAML.load_file(action_subscriber_config_file)[env]
+        yaml_config = ::YAML.load(::ERB.new(::File.read(action_subscriber_config_file)).result)[env]
       end
       yaml_config
     end

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -26,5 +26,16 @@ describe ::ActivePublisher::Configuration do
       expect(::ActivePublisher.configuration).to receive(:password=).with("WAT").and_return(true)
       ::ActivePublisher::Configuration.configure_from_yaml_and_cli({"password" => "WAT"}, true)
     end
+
+    context "when using a yaml file" do
+      let!(:sample_yaml_location) { ::File.expand_path(::File.join("spec", "support", "sample_config.yml")) }
+
+      before { allow(::File).to receive(:expand_path) { sample_yaml_location } }
+
+      it "parses any ERB in the yaml" do
+        expect(::ActivePublisher.configuration).to receive(:password=).with("WAT").and_return(true)
+        ::ActivePublisher::Configuration.configure_from_yaml_and_cli({}, true)
+      end
+    end
   end
 end

--- a/spec/support/sample_config.yml
+++ b/spec/support/sample_config.yml
@@ -1,2 +1,8 @@
 development:
   password: <%= "WAT" %>
+
+test:
+  password: <%= "WAT" %>
+
+production:
+  password: <%= "WAT" %>

--- a/spec/support/sample_config.yml
+++ b/spec/support/sample_config.yml
@@ -1,0 +1,2 @@
+development:
+  password: <%= "WAT" %>


### PR DESCRIPTION
Hey guys! I found one more issue while configuring this in our sandbox environment. The README gives an example config file using ERB and environment variables, but it looks like we weren't actually using ERB to read those settings in, causing us to get things like `<%= ENV["SUPER_SECRET_PASSWORD"] %>` in the settings instead of the result value, like `password1`. This resolves that so we can use ERB in the config file if needed

@mmmries @film42 