### PR TITLE
allow network_recovery_interval to be configurable

### DIFF
--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -6,6 +6,7 @@ module ActivePublisher
                   :heartbeat,
                   :host,
                   :hosts,
+                  :network_recovery_interval,
                   :password,
                   :port,
                   :publisher_confirms,
@@ -21,6 +22,7 @@ module ActivePublisher
                   :virtual_host
 
     CONFIGURATION_MUTEX = ::Mutex.new
+    NETWORK_RECOVERY_INTERVAL = 1.freeze
 
     DEFAULTS = {
       :error_handler => lambda { |error, env_hash|
@@ -32,6 +34,7 @@ module ActivePublisher
       :host => "localhost",
       :hosts => [],
       :password => "guest",
+      :network_recovery_interval => NETWORK_RECOVERY_INTERVAL,
       :port => 5672,
       :publisher_confirms => false,
       :publisher_confirms_timeout => 5_000, #specified as a number of milliseconds

--- a/lib/active_publisher/connection.rb
+++ b/lib/active_publisher/connection.rb
@@ -3,7 +3,6 @@ require 'thread'
 module ActivePublisher
   module Connection
     CONNECTION_MUTEX = ::Mutex.new
-    NETWORK_RECOVERY_INTERVAL = 1.freeze
 
     def self.connected?
       connection.try(:connected?)
@@ -46,7 +45,7 @@ module ActivePublisher
         :continuation_timeout          => ::ActivePublisher.configuration.timeout * 1_000.0, #convert sec to ms
         :heartbeat                     => ::ActivePublisher.configuration.heartbeat,
         :hosts                         => ::ActivePublisher.configuration.hosts,
-        :network_recovery_interval     => NETWORK_RECOVERY_INTERVAL,
+        :network_recovery_interval     => ::ActivePublisher.configuration.network_recovery_interval,
         :pass                          => ::ActivePublisher.configuration.password,
         :port                          => ::ActivePublisher.configuration.port,
         :recover_from_connection_close => true,

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -3,6 +3,7 @@ describe ::ActivePublisher::Configuration do
     specify { expect(subject.heartbeat).to eq(5) }
     specify { expect(subject.host).to eq("localhost") }
     specify { expect(subject.hosts).to eq(["localhost"]) }
+    specify { expect(subject.network_recovery_interval).to eq(1) }
     specify { expect(subject.port).to eq(5672) }
     specify { expect(subject.timeout).to eq(1) }
     specify { expect(subject.tls).to eq(false) }


### PR DESCRIPTION
We want to make network recovery "longer" in our environment but keep the backward compat with the default being 1 second

(although if you use that you should be aware that it is a value that can have a race condition if it is too low)

ruby-amqp/march_hare#83

This allows it to be configured by the configuration object/files

@film42 @quixoten