### PR TITLE
Switch the supervisor to a concurrent-ruby TimerTask

### DIFF
--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'activesupport', '>= 3.2'
-  spec.add_dependency 'multi_op_queue', '>= 0.1.2'
   spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'multi_op_queue', '>= 0.1.2'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'multi_op_queue', '>= 0.1.2'
+  spec.add_dependency 'concurrent-ruby'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -1,6 +1,7 @@
 require "active_publisher/message"
 require "active_publisher/async/in_memory_adapter/async_queue"
 require "active_publisher/async/in_memory_adapter/consumer_thread"
+require "concurrent"
 require "multi_op_queue"
 
 module ActivePublisher


### PR DESCRIPTION
It is within the realm of possibility that this can crash, so using
something more bullet-proof like concurrent-ruby's TimerTask makes quite
a bit of sense here.

We already have specs around consumer thread restarts, so this refactor was an easy one.

cc @abrandoned @quixoten 