### PR TITLE
Wait for a successful publish before deleting messages

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -63,25 +63,19 @@ module ActivePublisher
 
                 # Only open a single connection for each group of messages to an exchange
                 current_messages.group_by(&:exchange_name).each do |exchange_name, messages|
-                  begin
-                    current_messages -= messages
-                    publish_all(@channel, exchange_name, messages)
-                  ensure
-                    current_messages.concat(messages)
-                  end
+                  publish_all(@channel, exchange_name, messages)
+                  current_messages -= messages
                 end
               rescue *NETWORK_ERRORS
                 # Sleep because connection is down
                 await_network_reconnect
-
-                # Requeue and try again.
-                queue.concat(current_messages)
               rescue => unknown_error
                 ::ActivePublisher.configuration.error_handler.call(unknown_error, {:number_of_messages => current_messages.size})
                 current_messages.each do |message|
                   # Degrade to single message publish ... or at least attempt to
                   begin
                     ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
+                    current_messages.delete(message)
                   rescue => individual_error
                     ::ActivePublisher.configuration.error_handler.call(individual_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
                   end
@@ -90,6 +84,9 @@ module ActivePublisher
                 # TODO: Find a way to bubble this out of the thread for logging purposes.
                 # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
                 raise unknown_error
+              ensure
+                # Always requeue anything that gets stuck.
+                queue.concat(current_messages) unless current_messages.nil?
               end
             end
           end
@@ -98,37 +95,29 @@ module ActivePublisher
         def publish_all(channel, exchange_name, messages)
           ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :message_count => messages.size do
             exchange = channel.topic(exchange_name)
-            potentially_retry = []
-            loop do
-              break if messages.empty?
-              message = messages.shift
+            messages.each do |message|
+              # If we were given a bad message, it's important that we drop it right away to prevent it from retrying later.
+              unless message.is_a?(ActivePublisher::Message)
+                messages.delete(message)
+                fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message"
+              end
 
-              fail ActivePublisher::UnknownMessageClassError, "bulk publish messages must be ActivePublisher::Message" unless message.is_a?(ActivePublisher::Message)
               fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
 
-              begin
-                options = ::ActivePublisher.publishing_options(message.route, message.options || {})
-                exchange.publish(message.payload, options)
-                potentially_retry << message
-              rescue
-                messages << message
-                raise
-              end
+              options = ::ActivePublisher.publishing_options(message.route, message.options || {})
+              exchange.publish(message.payload, options)
             end
-            wait_for_confirms(channel, messages, potentially_retry)
+            wait_for_confirms(channel)
           end
         end
 
-        def wait_for_confirms(channel, messages, potentially_retry)
+        def wait_for_confirms(channel)
           return true unless channel.using_publisher_confirms?
           if channel.method(:wait_for_confirms).arity > 0
             channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
           else
             channel.wait_for_confirms
           end
-        rescue
-          messages.concat(potentially_retry)
-          raise
         end
       end
     end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -120,6 +120,21 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
         end
       end
 
+      context "when a channel closes" do
+        it "crashes the consumer" do
+          subject.push(message)
+          verify_expectation_within(0.5) do
+            expect(subject.size).to eq(0)
+          end
+
+          consumer.instance_variable_get(:@channel).close
+          subject.push(message)
+          verify_expectation_within(0.5) do
+            expect(subject.consumer.__id__).to_not eq(consumer.__id__)
+          end
+        end
+      end
+
       context "when a precondition errors occurs" do
         let(:bad_exchange_name) { "now_thats_what_i_call_music" }
         let(:bad_message) { ::ActivePublisher::Message.new(route, payload, bad_exchange_name, options) }

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -118,10 +118,19 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
         end
       end
 
+      context "when a malformed message is enqueued" do
+        it "deletes the message and raises an error" do
+          subject.queue.push(:yolo_dude)
+          verify_expectation_within(0.5) do
+            expect(subject.queue.size).to eq(0)
+          end
+        end
+      end
+
       context "when an unknown error occurs" do
         before { allow(consumer).to receive(:publish_all).and_raise(::ArgumentError) }
 
-        it "removes the message from the queue" do
+        it "processes the message and removes it from the queue" do
           expect(::ActivePublisher).to receive(:publish).with("test", "payload", "place", {:test => :ok}).and_call_original
           subject.push(message)
           verify_expectation_within(0.5) do

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -9,6 +9,8 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
   let(:back_pressure_strategy) { :raise }
   let(:max_queue_size) { 100 }
 
+  after { ::ActivePublisher::Connection.disconnect! }
+
   describe ".new" do
     context "defaults" do
       it "sets a default max queue size" do
@@ -115,6 +117,34 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
           expect(consumer).to be_alive
           subject.push(message)
           sleep 0.1 # Await results
+        end
+      end
+
+      context "when a precondition errors occurs" do
+        let(:bad_exchange_name) { "now_thats_what_i_call_music" }
+        let(:bad_message) { ::ActivePublisher::Message.new(route, payload, bad_exchange_name, options) }
+
+        it "only drops the bad message" do
+          # Declare a fanout exchange so the consumer thread will choke tring to declare a topic exchange.
+          channel = ::ActivePublisher::Connection.connection.create_channel
+          channel.fanout(bad_exchange_name)
+
+          reason = nil
+          collected_messages = []
+          allow(::ActivePublisher.configuration.error_handler).to receive(:call) do |err, options|
+            reason = options[:reason]
+            collected_messages << options[:message] if options[:message]
+          end
+
+          messages = [message, bad_message]
+          subject.queue.concat(messages)
+
+          verify_expectation_within(5) do
+            expect(reason).to eq("precondition failed")
+            expect(subject.queue.size).to eq(0)
+          end
+
+          expect(collected_messages).to eq([bad_message])
         end
       end
 


### PR DESCRIPTION
I branched off #38 because these should go together, but I wanted to discuss the merits in a separate PR.

In master, when a consumer dies, we potentially drop the current batch of messages with it. This PR changes this so we only remove items from the current batch of messages when either are true:
1. the message or mini-batch are successfully published to rabbitmq.
2. a non `ActivePublisher::Message` instance is enqueued.

So now, a consumer can be killed at any moment and messages will be retried in the new consumer.

Are there any potential dangers? Yes. Now that we always requeue messages that haven't been processed yet, a bad message can cause the publisher to churn quickly. For now I've focused on rejecting messages that aren't active publisher messages from the beginning, but it wouldn't be terribly difficult to count message retries and drop after 10 or something.

cc @abrandoned @quixoten @mmmries 