### PR TITLE
Cache declared exchanges for async publisher

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -1,5 +1,6 @@
 require "active_publisher/message"
 require "active_publisher/async/in_memory_adapter/async_queue"
+require "active_publisher/async/in_memory_adapter/channel"
 require "active_publisher/async/in_memory_adapter/consumer_thread"
 require "concurrent"
 require "multi_op_queue"

--- a/lib/active_publisher/async/in_memory_adapter/channel.rb
+++ b/lib/active_publisher/async/in_memory_adapter/channel.rb
@@ -1,0 +1,43 @@
+module ActivePublisher
+  module Async
+    module InMemoryAdapter
+      ##
+      # This class is a wrapper around bunny and march hare channels to cache exchanges.
+      # Bunny does this by default, but march hare will perform a blocking wait for each
+      # exchange declaration.
+      #
+      class Channel
+        attr_reader :rabbit_channel, :topic_exchange_cache
+
+        def initialize
+          @topic_exchange_cache = {}
+          @rabbit_channel = ::ActivePublisher::Connection.connection.create_channel
+        end
+
+        def close
+          rabbit_channel.close
+        end
+
+        def confirm_select
+          rabbit_channel.confirm_select
+        end
+
+        def topic(exchange)
+          topic_exchange_cache[exchange] ||= rabbit_channel.topic(exchange)
+        end
+
+        def using_publisher_confirms?
+          rabbit_channel.using_publisher_confirms?
+        end
+
+        def wait_for_confirms(timeout)
+          if rabbit_channel.method(:wait_for_confirms).arity > 0
+            rabbit_channel.wait_for_confirms(timeout)
+          else
+            rabbit_channel.wait_for_confirms
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -46,7 +46,7 @@ module ActivePublisher
         end
 
         def make_channel
-          channel = ::ActivePublisher::Connection.connection.create_channel
+          channel = ::ActivePublisher::Async::InMemoryAdapter::Channel.new
           channel.confirm_select if ::ActivePublisher.configuration.publisher_confirms
           channel
         end

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -122,11 +122,7 @@ module ActivePublisher
 
         def wait_for_confirms(channel)
           return true unless channel.using_publisher_confirms?
-          if channel.method(:wait_for_confirms).arity > 0
-            channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
-          else
-            channel.wait_for_confirms
-          end
+          channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
         end
       end
     end

--- a/spec/lib/active_publisher/async/in_memory_adapter/channel_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter/channel_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe ::ActivePublisher::Async::InMemoryAdapter::Channel do
+  describe "#topic" do
+    it "caches a declared topic exchange" do
+      exchange1 = subject.topic("asnyc_publisher_testing.random_topic_exchange")
+      exchange2 = subject.topic("asnyc_publisher_testing.random_topic_exchange")
+
+      expect(exchange1.__id__).to eq(exchange2.__id__)
+    end
+  end
+
+  describe "#close" do
+    it "proxies the close call" do
+      expect(subject.rabbit_channel).to receive(:close)
+      subject.close
+    end
+  end
+
+  describe "#using_publisher_confirms?" do
+    it "proxies the using_publisher_confirms? call" do
+      expect(subject.using_publisher_confirms?).to eq(false)
+      subject.confirm_select
+      expect(subject.using_publisher_confirms?).to eq(true)
+    end
+  end
+
+  describe "#wait_for_confirms" do
+    it "proxies the wait_for_confirms call" do
+      expect(subject.rabbit_channel).to receive(:wait_for_confirms)
+      subject.wait_for_confirms(1)
+    end
+  end
+end


### PR DESCRIPTION
I was investigating and found that bunny caches exchanges but march hare does not. With this change we're able to cache declared exchanges and avoid a round-trip blocking call.

I'm not sure how much of an impact this has on publisher latency, but I'm hoping to find out very soon :).

cc @abrandoned @quixoten @liveh2o @brianstien @jjcarstens 