### PR TITLE
reconnect on both async and with_exchange publish calls and consolida…

### DIFF
--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -98,17 +98,11 @@ module ActivePublisher
   end
 
   def self.with_exchange(exchange_name)
-    total_recovery_wait = 0
-
     begin
       connection = ::ActivePublisher::Connection.connection
       channel = connection.create_channel
     rescue *NETWORK_ERRORS
-      # Connection will auto-recover asynchronously; if we are "waiting" for that to happen for longer than 5 minutes then we should
-      # just disconnect and reconnect the connection (which will be done automatically on disconnect)
-      total_recovery_wait += 0.5
-      sleep 0.5
-      ::ActivePublisher::Connection.disconnect! if total_recovery_wait > 600
+      ::ActivePublisher::Connection.disconnect!
     end
 
     begin

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -5,14 +5,6 @@ module ActivePublisher
         attr_reader :thread, :queue, :sampled_queue_size, :last_tick_at
 
         if ::RUBY_PLATFORM == "java"
-          NETWORK_ERRORS = [::MarchHare::NetworkException, ::MarchHare::ConnectionRefused,
-                            ::Java::ComRabbitmqClient::AlreadyClosedException, ::Java::JavaIo::IOException].freeze
-        else
-          NETWORK_ERRORS = [::Bunny::NetworkFailure, ::Bunny::TCPConnectionFailed, ::Bunny::ConnectionTimeout,
-                            ::Timeout::Error, ::IOError].freeze
-        end
-
-        if ::RUBY_PLATFORM == "java"
           PRECONDITION_ERRORS = [::MarchHare::PreconditionFailed]
         else
           PRECONDITION_ERRORS = [::Bunny::PreconditionFailed]
@@ -77,7 +69,7 @@ module ActivePublisher
                   publish_all(@channel, exchange_name, messages)
                   current_messages -= messages
                 end
-              rescue *NETWORK_ERRORS
+              rescue *ActivePublisher::NETWORK_ERRORS
                 # Sleep because connection is down
                 await_network_reconnect
               rescue => unknown_error

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -110,7 +110,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       end
 
       context "when network error occurs" do
-        let(:error) { ActivePublisher::Async::InMemoryAdapter::ConsumerThread::NETWORK_ERRORS.first }
+        let(:error) { ::ActivePublisher::NETWORK_ERRORS.first }
         before { allow(consumer).to receive(:publish_all).and_raise(error) }
 
         it "requeues the message" do


### PR DESCRIPTION
…te where errors are stored

I think this was discussed today so wanted to get something out there that we can use and hopefully stop losing some of the messages on publish when done synchronously

@film42 @liveh2o @newellista 