### PR TITLE
Add route to publish instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ rvm:
  - 2.3
  - 2.4
  - jruby-9.1.12.0
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 services:
  - rabbitmq
 sudo: false

--- a/lib/active_publisher.rb
+++ b/lib/active_publisher.rb
@@ -35,7 +35,7 @@ module ActivePublisher
   # @param [Hash] options hash to set message parameters (e.g. headers)
   def self.publish(route, payload, exchange_name, options = {})
     with_exchange(exchange_name) do |exchange|
-      ::ActiveSupport::Notifications.instrument "message_published.active_publisher" do
+      ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :route => route do
         exchange.publish(payload, publishing_options(route, options))
       end
     end
@@ -51,7 +51,7 @@ module ActivePublisher
         fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
 
         begin
-          ::ActiveSupport::Notifications.instrument "message_published.active_publisher" do
+          ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :route => message.route do
             exchange.publish(message.payload, publishing_options(message.route, message.options || {}))
           end
         rescue

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -110,7 +110,7 @@ module ActivePublisher
         def publish_all(channel, exchange_name, messages)
           exchange = channel.topic(exchange_name)
           messages.each do |message|
-            fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
+            fail ::ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
             ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :route => message.route, :message_count => 1 do
               options = ::ActivePublisher.publishing_options(message.route, message.options || {})
               exchange.publish(message.payload, options)

--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -108,16 +108,15 @@ module ActivePublisher
         end
 
         def publish_all(channel, exchange_name, messages)
-          ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :message_count => messages.size do
-            exchange = channel.topic(exchange_name)
-            messages.each do |message|
-              fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
-
+          exchange = channel.topic(exchange_name)
+          messages.each do |message|
+            fail ActivePublisher::ExchangeMismatchError, "bulk publish messages must match publish_all exchange_name" if message.exchange_name != exchange_name
+            ::ActiveSupport::Notifications.instrument "message_published.active_publisher", :route => message.route, :message_count => 1 do
               options = ::ActivePublisher.publishing_options(message.route, message.options || {})
               exchange.publish(message.payload, options)
             end
-            wait_for_confirms(channel)
           end
+          wait_for_confirms(channel)
         end
 
         def wait_for_confirms(channel)

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -103,7 +103,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
     describe "#create_consumer" do
       it "can successfully publish a message" do
         expect(::ActiveSupport::Notifications).to receive(:instrument)
-                                                    .with("message_published.active_publisher",:message_count => 1)
+                                                    .with("message_published.active_publisher", :route => "test", :message_count => 1)
         expect(consumer).to receive(:publish_all).with(anything, exchange_name, [message]).and_call_original
         subject.push(message)
         sleep 0.1 # Await results


### PR DESCRIPTION
Adds the message route to the publish instrumentation so we can see message volume to each route individually.

See mxenabled/harness-active_publisher#6

CC @film42