### PR TITLE
add the ability to pause publishing in the redis queue and lengthen t…

### DIFF
--- a/lib/active_publisher/async/redis_adapter.rb
+++ b/lib/active_publisher/async/redis_adapter.rb
@@ -13,6 +13,7 @@ module ActivePublisher
       end
 
       class Adapter
+        QUEUE_FLUSH_SIZE = 100
         SUPERVISOR_INTERVAL = {
           :execution_interval => 1.5, # seconds
           :timeout_interval => 1, # seconds
@@ -41,7 +42,7 @@ module ActivePublisher
         def publish(route, payload, exchange_name, options = {})
           message = ::ActivePublisher::Message.new(route, payload, exchange_name, options)
           queue << ::Marshal.dump(message)
-          flush_queue! if queue.size >= 20 || options[:flush_queue]
+          flush_queue! if queue.size >= QUEUE_FLUSH_SIZE || options[:flush_queue]
 
           nil
         end

--- a/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
+++ b/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
@@ -2,6 +2,8 @@ module ActivePublisher
   module Async
     module RedisAdapter
       class RedisMultiPopQueue
+        RABBITMQ_PAUSED_KEY = "ACTIVE_PUBLISHER_RABBITMQ_PAUSED".freeze
+
         attr_reader :list_key, :redis_pool
 
         def initialize(redis_connection_pool, new_list_key)
@@ -34,6 +36,12 @@ module ActivePublisher
 
         def empty?
           size <= 0
+        end
+
+        def pause_publishing?
+          redis_pool.with do |redis|
+            redis.exists(RABBITMQ_PAUSED_KEY)
+          end
         end
 
         def pop_up_to(num_to_pop, opts = {})
@@ -73,6 +81,7 @@ module ActivePublisher
         def shift(number)
           number = [number, size].min
           return [] if number <= 0
+          return [] if pause_publishing?
 
           messages = []
           multi_response = []

--- a/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
+++ b/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
@@ -40,7 +40,7 @@ module ActivePublisher
 
         def pause_publishing?
           redis_pool.with do |redis|
-            redis.exists(RABBITMQ_PAUSED_KEY)
+            redis.exists?(RABBITMQ_PAUSED_KEY)
           end
         end
 


### PR DESCRIPTION
…he value of in memory queue before flushing to redis

abstract into a constant the in memory queue size that will synchronously flush to redis (don't even know if we should have this in there but should be higher than 20)

Also added the ability to pause the publishing from redis, so we can easily stop the publish while doing maint on a rabbit cluster or something

thoughts? 

@liveh2o @film42 @elbowdonkey 