### PR TITLE
Clean up channel when consumer thread exits

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -2,7 +2,13 @@ module ActivePublisher
   module Async
     module InMemoryAdapter
       class ConsumerThread
-        attr_reader :thread, :queue, :sampled_queue_size, :last_tick_at
+        attr_reader :channel, :thread, :queue, :sampled_queue_size, :last_tick_at
+
+        if ::RUBY_PLATFORM == "java"
+          CHANNEL_CLOSED_ERRORS = [::MarchHare::ChannelAlreadyClosed]
+        else
+          CHANNEL_CLOSED_ERRORS = [::Bunny::ChannelAlreadyClosed]
+        end
 
         if ::RUBY_PLATFORM == "java"
           NETWORK_ERRORS = [::MarchHare::NetworkException, ::MarchHare::ConnectionRefused,
@@ -45,6 +51,32 @@ module ActivePublisher
           end
         end
 
+        def cleanup_up_channel
+          return if @channel.nil?
+          @channel.close
+        rescue => error
+          ::ActivePublisher.configuration.error_handler.call(error, {:status => "Cleaning up the channel"})
+        end
+
+        def handle_current_messages_on_unknown_error(current_messages)
+          current_messages.each do |message|
+            # Degrade to single message publish ... or at least attempt to
+            begin
+              ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
+              current_messages.delete(message)
+            rescue *CHANNEL_CLOSED_ERRORS
+              # If the channel is bad, raise!
+              raise
+            rescue *PRECONDITION_ERRORS => error
+              # Delete messages if rabbitmq cannot declare the exchange (or somet other precondition failed).
+              ::ActivePublisher.configuration.error_handler.call(error, {:reason => "precondition failed", :message => message})
+              current_messages.delete(message)
+            rescue => other_error
+              ::ActivePublisher.configuration.error_handler.call(other_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
+            end
+          end
+        end
+
         def make_channel
           channel = ::ActivePublisher::Async::InMemoryAdapter::Channel.new
           channel.confirm_select if ::ActivePublisher.configuration.publisher_confirms
@@ -57,54 +89,50 @@ module ActivePublisher
 
         def start_thread
           return if alive?
-          @thread = ::Thread.new do
-            loop do
-              # Sample the queue size so we don't shutdown when messages are in flight.
-              @sampled_queue_size = queue.size
-              current_messages = queue.pop_up_to(50, :timeout => 0.1)
-              update_last_tick_at
-              # If the queue is empty, we should continue to update to "last_tick_at" time.
-              next if current_messages.nil?
+          @channel = make_channel
+          @thread = ::Thread.new { start_consuming_thread }
+        end
 
-              # We only look at active publisher messages. Everything else is dropped.
-              current_messages.select! { |message| message.is_a?(::ActivePublisher::Message) }
+        def start_consuming_thread
+          loop do
+            # Sample the queue size so we don't shutdown when messages are in flight.
+            @sampled_queue_size = queue.size
+            current_messages = queue.pop_up_to(50, :timeout => 0.1)
+            update_last_tick_at
+            # If the queue is empty, we should continue to update to "last_tick_at" time.
+            next if current_messages.nil?
 
-              begin
-                @channel ||= make_channel
+            # We only look at active publisher messages. Everything else is dropped.
+            current_messages.select! { |message| message.is_a?(::ActivePublisher::Message) }
 
-                # Only open a single connection for each group of messages to an exchange
-                current_messages.group_by(&:exchange_name).each do |exchange_name, messages|
-                  publish_all(@channel, exchange_name, messages)
-                  current_messages -= messages
-                end
-              rescue *NETWORK_ERRORS
-                # Sleep because connection is down
-                await_network_reconnect
-              rescue => unknown_error
-                ::ActivePublisher.configuration.error_handler.call(unknown_error, {:number_of_messages => current_messages.size})
-                current_messages.each do |message|
-                  # Degrade to single message publish ... or at least attempt to
-                  begin
-                    ::ActivePublisher.publish(message.route, message.payload, message.exchange_name, message.options)
-                    current_messages.delete(message)
-                  rescue *PRECONDITION_ERRORS => error
-                    # Delete messages if rabbitmq cannot declare the exchange (or somet other precondition failed).
-                    ::ActivePublisher.configuration.error_handler.call(error, {:reason => "precondition failed", :message => message})
-                    current_messages.delete(message)
-                  rescue => individual_error
-                    ::ActivePublisher.configuration.error_handler.call(individual_error, {:route => message.route, :payload => message.payload, :exchange_name => message.exchange_name, :options => message.options})
-                  end
-                end
-
-                # TODO: Find a way to bubble this out of the thread for logging purposes.
-                # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
-                raise unknown_error
-              ensure
-                # Always requeue anything that gets stuck.
-                queue.concat(current_messages) if current_messages && !current_messages.empty?
+            begin
+              # Only open a single connection for each group of messages to an exchange
+              current_messages.group_by(&:exchange_name).each do |exchange_name, messages|
+                publish_all(@channel, exchange_name, messages)
+                current_messages -= messages
               end
+            rescue *CHANNEL_CLOSED_ERRORS
+              # If the channel is bad, raise without sending one-by-one!
+              raise
+            rescue *NETWORK_ERRORS
+              # Sleep because connection is down
+              await_network_reconnect
+            rescue => unknown_error
+              ::ActivePublisher.configuration.error_handler.call(unknown_error, {:number_of_messages => current_messages.size})
+
+              # Attempt to deliver a message one-by-one. Raise if a closed channel error appears.
+              handle_current_messages_on_unknown_error(current_messages)
+
+              # TODO: Find a way to bubble this out of the thread for logging purposes.
+              # Reraise the error out of the publisher loop. The Supervisor will restart the consumer.
+              raise unknown_error
+            ensure
+              # Always requeue anything that gets stuck.
+              queue.concat(current_messages) if current_messages && !current_messages.empty?
             end
           end
+        ensure
+          cleanup_up_channel
         end
 
         def publish_all(channel, exchange_name, messages)


### PR DESCRIPTION
It's EOD but I wanted to sketch out this PR. The basic idea is to always close channels when the consumer thread bails, and catch `ChannelAlreadClosed` to ensure we're baling out as early as possible.

I believe this will fix the following error:
```
[ERROR] [2020-11-08 14:45:37 -0700] /srv/grunt/shared/bundle/jruby/2.5.0/gems/march_hare-2.22.0-java/lib/march_hare/session.rb:177:in `create_channel'
/srv/grunt/shared/bundle/jruby/2.5.0/gems/active_publisher-1.2.3-java/lib/active_publisher.rb:85:in `with_exchange'
/srv/grunt/shared/bundle/jruby/2.5.0/gems/active_publisher-1.2.3-java/lib/active_publisher.rb:37:in `publish'
/srv/grunt/shared/bundle/jruby/2.5.0/gems/active_publisher-1.2.3-java/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb:88:in `block in start_thread'
org/jruby/RubyArray.java:1792:in `each'
/srv/grunt/shared/bundle/jruby/2.5.0/gems/active_publisher-1.2.3-java/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb:85:in `block in start_thread'
org/jruby/RubyKernel.java:1411:in `loop'
/srv/grunt/shared/bundle/jruby/2.5.0/gems/active_publisher-1.2.3-java/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb:61:in `block in start_thread'
[ERROR] [2020-11-08 14:45:37 -0700] MarchHare::ChannelError
[ERROR] [2020-11-08 14:45:37 -0700]           Unable to create a channel. This is likely due to having a channel_max setting
          on the rabbitmq broker (see https://www.rabbitmq.com/configure.html).
          There are currently 1024 channels on this connection.
```

@abrandoned 