### PR TITLE
don't create channel too soon

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -89,7 +89,6 @@ module ActivePublisher
 
         def start_thread
           return if alive?
-          @channel = make_channel
           @thread = ::Thread.new { start_consuming_thread }
         end
 
@@ -101,6 +100,8 @@ module ActivePublisher
             update_last_tick_at
             # If the queue is empty, we should continue to update to "last_tick_at" time.
             next if current_messages.nil?
+
+            @channel ||= make_channel
 
             # We only look at active publisher messages. Everything else is dropped.
             current_messages.select! { |message| message.is_a?(::ActivePublisher::Message) }

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -122,7 +122,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
       it "can successfully publish a message" do
         expect(::ActiveSupport::Notifications).to receive(:instrument)
                                                     .with("message_published.active_publisher", :route => "test", :message_count => 1)
-        expect(consumer).to receive(:publish_all).with(anything, exchange_name, [message]).and_call_original
+        expect(consumer).to receive(:publish_all).with(exchange_name, [message]).and_call_original
         subject.push(message)
         sleep 0.1 # Await results
       end


### PR DESCRIPTION
Restore behavior to not create the channel until at least one message is in the queue.

Creating it too early can cause specs in other projects to fail or rely on rabbitmq being installed (and running) even in projects that include active_publisher and initialize it upfront but don't actually publish any messages (in the specs).

Also, make use of the attr_reader that we now have for channel.

@liveh2o @film42 @brianstien 