### PR TITLE
Adds instrumentation for publish_confirms latency metric

### DIFF
--- a/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
+++ b/lib/active_publisher/async/in_memory_adapter/consumer_thread.rb
@@ -151,7 +151,9 @@ module ActivePublisher
 
         def wait_for_confirms
           return true unless channel.using_publisher_confirms?
-          channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
+          ::ActiveSupport::Notifications.instrument "publishes_confirmed.active_publisher" do
+            channel.wait_for_confirms(::ActivePublisher.configuration.publisher_confirms_timeout)
+          end
         end
       end
     end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -167,6 +167,18 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
         sleep 0.1 # Await results
       end
 
+      describe "when publish confirms enabled" do
+        it "notifies active support with an instrumentation" do
+          ::ActivePublisher.configuration.publisher_confirms = true
+          expect(::ActiveSupport::Notifications).to receive(:instrument)
+                                                    .with("message_published.active_publisher", :route => "test", :message_count => 1)
+          expect(::ActiveSupport::Notifications).to receive(:instrument).with("publishes_confirmed.active_publisher")
+          expect(consumer).to receive(:publish_all).with(exchange_name, [message]).and_call_original
+          subject.push(message)
+          sleep 0.1 # Await results
+        end
+      end
+
       context "when network error occurs" do
         let(:error) { ActivePublisher::Async::InMemoryAdapter::ConsumerThread::NETWORK_ERRORS.first }
         before { allow(consumer).to receive(:publish_all).and_raise(error) }


### PR DESCRIPTION
Currently we measure message publishing latency.  But if publish_confirms is used it doesn't tell the entire story.  This adds an ActiveSupport::Notification for when the publisher thread waits for publish confirms from RabbitMQ.