### PR TITLE
Update redis pipelining commands

### DIFF
--- a/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
+++ b/lib/active_publisher/async/redis_adapter/redis_multi_pop_queue.rb
@@ -77,9 +77,9 @@ module ActivePublisher
           messages = []
           multi_response = []
           redis_pool.with do |redis|
-            multi_response = redis.multi do
-              redis.lrange(list_key, 0, number - 1)
-              redis.ltrim(list_key, number, -1)
+            multi_response = redis.multi do |pipeline|
+              pipeline.lrange(list_key, 0, number - 1)
+              pipeline.ltrim(list_key, number, -1)
             end
           end
 


### PR DESCRIPTION
Fix deprecation warnings with newer versions of redis gem.
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end
```