### PR TITLE
Fix YAML loading

### DIFF
--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'multi_op_queue', '>= 0.2.0'
+  spec.add_dependency 'psych', '>= 3.3.2'
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler"

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -83,11 +83,13 @@ module ActivePublisher
       yaml_config = {}
       absolute_config_path = ::File.expand_path(::File.join("config", "active_publisher.yml"))
       action_subscriber_config_file = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
+
       if ::File.exists?(absolute_config_path)
-        yaml_config = ::YAML.load(::ERB.new(::File.read(absolute_config_path)).result)[env]
+        yaml_config = load_yaml_config_from_file(absolute_config_path)[env]
       elsif ::File.exists?(action_subscriber_config_file)
-        yaml_config = ::YAML.load(::ERB.new(::File.read(action_subscriber_config_file)).result)[env]
+        yaml_config = load_yaml_config_from_file(action_subscriber_config_file)[env]
       end
+
       yaml_config
     end
     private_class_method :attempt_to_load_yaml_file
@@ -100,6 +102,14 @@ module ActivePublisher
       [false, nil]
     end
     private_class_method :fetch_config_value
+
+    def self.load_yaml_config_from_file(file_path)
+      erb_yaml = ::ERB.new(::File.read(file_path)).result
+      # Defined in Psych 3.2+ and the new canonical way to load trusted documents:
+      # https://github.com/ruby/psych/issues/533#issuecomment-1019363688
+      ::YAML.unsafe_load(erb_yaml)
+    end
+    private_class_method :load_yaml_config_from_file
 
     ##
     # Instance Methods


### PR DESCRIPTION
Psych (aka YAML) 4.x included a breaking change to how `YAML.load` works In Psych 4.0, `load` calls `safe_load` under the hood, and is therefore "safe" by default, but that breaks configurations that support (among other things) aliases, which are disabled when using "safe" loading.

`unsafe_load` is now the canonical way to load trusted documents (i.e., config files): https://github.com/ruby/psych/issues/533#issuecomment-1019363688

To ensure maximum compatibility with old versions of Psych, we also need to set a minimum version of Psych to ensure `unsafe_load` is defined. The methods were introduced in v3.3.2: https://github.com/ruby/psych/commit/cb50aa8d3fb8be01897becff77b4922b12a0ab4c

Resolves #60