### PR TITLE
Update supported Ruby versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ workflows:
           matrix:
             parameters:
               ruby-image:
-                - circleci/ruby:2.5
                 - circleci/ruby:2.6
                 - circleci/ruby:2.7
-                - circleci/jruby:9.1
+                - cimg/ruby:3.0
+                - cimg/ruby:3.1
                 - circleci/jruby:9.2
                 - circleci/jruby:9.3


### PR DESCRIPTION
Ruby 2.5 and JRuby 9.1 have reached EOL, and are no longer supported. Drop them from the CI config.

Conversely, Ruby 3.0 and 3.1 have been released and are supported, so add them to the CI config.

// @film42 @ETetzlaff @skunkworker 