### PR TITLE
Remove minimum Psych constraint

### DIFF
--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'multi_op_queue', '>= 0.2.0'
-  spec.add_dependency 'psych', '>= 3.3.2'
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler"

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -107,7 +107,7 @@ module ActivePublisher
       erb_yaml = ::ERB.new(::File.read(file_path)).result
       # Defined in Psych 3.2+ and the new canonical way to load trusted documents:
       # https://github.com/ruby/psych/issues/533#issuecomment-1019363688
-      ::YAML.unsafe_load(erb_yaml)
+      ::YAML.respond_to?(:unsafe_load) ? ::YAML.unsafe_load(erb_yaml) : ::YAML.load(erb_yaml)
     end
     private_class_method :load_yaml_config_from_file
 


### PR DESCRIPTION
Rails < 6.0 uses the old way of loading YAML files. This breaks loading database configs with aliases (a common development practice) with Psych 4.x. Adding a minimum version of Psych to the gemspec here forces an upgrade to Psych 4.x, which means we end up having to pin Psych to 3.3.2.

Rails 6.1 solves this problem by [checking](https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/secrets.rb#L29) if the new unsafe_load method exists, and falling back to load if it doesn't. That's a better way.

Resolves #63.