### PR TITLE
Adds max_message_bytes config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Defaults for the configuration are:
   :host => "localhost",
   :hosts => [],
   :max_async_publisher_lag_time => 10,
+  :max_message_bytes => 67108864,
   :network_recovery_interval => 1,
   :password => "guest",
   :port => 5672,

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -31,9 +31,9 @@ module ActivePublisher
         end
 
         def push(message)
-          if message.payload.bytesize > ::ActivePublisher.configuration.max_message_size
+          if message.payload.bytesize > ::ActivePublisher.configuration.max_message_bytes
             ::ActiveSupport::Notifications.instrument "message_dropped.active_publisher"
-            fail ::ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError, "Message dropped. Message payload is larger than max_message_size."
+            fail ::ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError, "Message dropped. Message payload is larger than max_message_bytes."
           end
 
           if queue.size >= max_queue_size

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -8,6 +8,7 @@ module ActivePublisher
                   :host,
                   :hosts,
                   :max_async_publisher_lag_time,
+                  :max_message_size,
                   :messages_per_batch,
                   :network_recovery_interval,
                   :password,
@@ -40,6 +41,7 @@ module ActivePublisher
       :password => "guest",
       :messages_per_batch => 25,
       :max_async_publisher_lag_time => 10,
+      :max_message_size => 67108864, # 64 MB
       :network_recovery_interval => NETWORK_RECOVERY_INTERVAL,
       :port => 5672,
       :publisher_threads => 1,

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -41,7 +41,7 @@ module ActivePublisher
       :password => "guest",
       :messages_per_batch => 25,
       :max_async_publisher_lag_time => 10,
-      :max_message_bytes => 67108864, # 64 MB
+      :max_message_bytes => 67108864,
       :network_recovery_interval => NETWORK_RECOVERY_INTERVAL,
       :port => 5672,
       :publisher_threads => 1,

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -8,7 +8,7 @@ module ActivePublisher
                   :host,
                   :hosts,
                   :max_async_publisher_lag_time,
-                  :max_message_size,
+                  :max_message_bytes,
                   :messages_per_batch,
                   :network_recovery_interval,
                   :password,
@@ -41,7 +41,7 @@ module ActivePublisher
       :password => "guest",
       :messages_per_batch => 25,
       :max_async_publisher_lag_time => 10,
-      :max_message_size => 67108864, # 64 MB
+      :max_message_bytes => 67108864, # 64 MB
       :network_recovery_interval => NETWORK_RECOVERY_INTERVAL,
       :port => 5672,
       :publisher_threads => 1,

--- a/spec/lib/active_publisher/async/in_memory_adapter/async_queue_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter/async_queue_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+describe ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue do
+  let(:route) { "test" }
+  let(:payload) { "a" * (::ActivePublisher.configuration.max_message_size + 1) }
+  let(:exchange_name) { "place" }
+  let(:options) { { :test => :ok } }
+  let(:message) { ::ActivePublisher::Message.new(route, payload, exchange_name, options) }
+  let(:mock_queue) { double(:push => nil, :size => 0) }
+
+  subject { described_class.new(:raise, 1, 1) }
+
+  describe "#push" do
+    context "when the messsage payload is larger than max_message_size" do
+      it "raises an error" do
+        expect { subject.push(message) }.to raise_error(ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError)
+      end
+    end
+  end
+end

--- a/spec/lib/active_publisher/async/in_memory_adapter/async_queue_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter/async_queue_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue do
   let(:route) { "test" }
-  let(:payload) { "a" * (::ActivePublisher.configuration.max_message_size + 1) }
+  let(:payload) { "a" * (::ActivePublisher.configuration.max_message_bytes + 1) }
   let(:exchange_name) { "place" }
   let(:options) { { :test => :ok } }
   let(:message) { ::ActivePublisher::Message.new(route, payload, exchange_name, options) }
@@ -11,7 +11,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::AsyncQueue do
   subject { described_class.new(:raise, 1, 1) }
 
   describe "#push" do
-    context "when the messsage payload is larger than max_message_size" do
+    context "when the messsage payload is larger than max_message_bytes" do
       it "raises an error" do
         expect { subject.push(message) }.to raise_error(ActivePublisher::Async::InMemoryAdapter::UnableToPersistMessageError)
       end

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -4,6 +4,7 @@ describe ::ActivePublisher::Configuration do
     specify { expect(subject.host).to eq("localhost") }
     specify { expect(subject.hosts).to eq(["localhost"]) }
     specify { expect(subject.max_async_publisher_lag_time).to eq(10) }
+    specify { expect(subject.max_message_size).to eq(67108864) }
     specify { expect(subject.network_recovery_interval).to eq(1) }
     specify { expect(subject.publisher_threads).to eq(1) }
     specify { expect(subject.port).to eq(5672) }

--- a/spec/lib/active_publisher/configuration_spec.rb
+++ b/spec/lib/active_publisher/configuration_spec.rb
@@ -4,7 +4,7 @@ describe ::ActivePublisher::Configuration do
     specify { expect(subject.host).to eq("localhost") }
     specify { expect(subject.hosts).to eq(["localhost"]) }
     specify { expect(subject.max_async_publisher_lag_time).to eq(10) }
-    specify { expect(subject.max_message_size).to eq(67108864) }
+    specify { expect(subject.max_message_bytes).to eq(67108864) }
     specify { expect(subject.network_recovery_interval).to eq(1) }
     specify { expect(subject.publisher_threads).to eq(1) }
     specify { expect(subject.port).to eq(5672) }


### PR DESCRIPTION
Adds `max_message_bytes` config option, defaults to 64 MB. Drops messages larger than `max_message_bytes` and raises an error.