### PR TITLE
move multi op queue internal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,57 +1,92 @@
-# Inspired by: http://mikebian.co/running-tests-against-multiple-ruby-versions-using-circleci/
-
 version: 2.1
 
-orbs:
-  ruby: circleci/ruby@1.1
-
 jobs:
-  test:
-    parallelism: 1
+  build_and_test:
     parameters:
-      ruby-image:
+      docker_image:
         type: string
+        description: "The Ruby or JRuby Docker image to test against"
+
     docker:
-      - image: << parameters.ruby-image >>
-      - image: rabbitmq
+      # 1. The Primary Container (where your code actually runs)
+      - image: << parameters.docker_image >>
+        environment:
+          JRUBY_OPTS: "-J-Xmx1024m"
+          RAILS_ENV: test
+          # Tell your app where to find RabbitMQ (if your app uses this ENV var)
+          RABBITMQ_URL: "amqp://guest:guest@localhost:5672"
+
+      # 2. The Service Container (runs in the background)
+      - image: rabbitmq:3
+        # If you need the management UI for debugging, use `rabbitmq:3-management` instead
+        # environment:
+        #   RABBITMQ_DEFAULT_USER: guest
+        #   RABBITMQ_DEFAULT_PASS: guest
+
+    working_directory: ~/project
 
     steps:
       - checkout
+
       - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
+          name: Install System Dependencies
+          command: |
+            if [ "$(id -u)" = "0" ]; then
+              apt-get update && apt-get install -y build-essential git
+            else
+              sudo apt-get update && sudo apt-get install -y build-essential git
+            fi
+
+      # Note: We added the docker_image parameter to the cache key
+      # so MRI and JRuby gems don't conflict.
+      - restore_cache:
+          keys:
+            - v1-gems-<< parameters.docker_image >>-{{ checksum "Gemfile.lock" }}
+            - v1-gems-<< parameters.docker_image >>-
+
       - run:
-          name: Wait for rabbitmq
-          command: dockerize -wait tcp://localhost:5672 -timeout 1m
+          name: Install Ruby Dependencies
+          command: |
+            gem install bundler
+            bundle config set --local path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-gems-<< parameters.docker_image >>-{{ checksum "Gemfile.lock" }}
+
+      # Wait for RabbitMQ to be ready before running tests.
+      # Service containers can sometimes take a few seconds to boot up.
       - run:
-          name: Install bundler
-          command: gem install bundler
+          name: Wait for RabbitMQ
+          command: |
+            if [ "$(id -u)" = "0" ]; then
+              apt-get install -y netcat-openbsd
+            else
+              sudo apt-get install -y netcat-openbsd
+            fi
+
+            echo "Waiting for RabbitMQ to start..."
+            while ! nc -z localhost 5672; do
+              sleep 1
+            done
+            echo "RabbitMQ is ready!"
+
       - run:
-          name: Which bundler?
-          command: bundle -v
-      - run:
-          name: bundle install
-          command: bundle install
-      - run:
-          name: rspec
+          name: Run Tests
           command: bundle exec rspec
 
-# strangely, there seems to be very little documentation about exactly how martix builds work.
-# By defining a param inside your job definition, Circle CI will automatically spawn a job for
-# unique param value passed via `matrix`. Neat!
-# https://circleci.com/blog/circleci-matrix-jobs/
 workflows:
-  build_and_test:
+  version: 2
+  ruby_compatibility_matrix:
     jobs:
-      - test:
+      - build_and_test:
+          name: test-<< matrix.docker_image >>
           matrix:
             parameters:
-              ruby-image:
-                - circleci/ruby:2.6
-                - circleci/ruby:2.7
-                - cimg/ruby:3.0
-                - cimg/ruby:3.1
-                - circleci/jruby:9.2
-                - circleci/jruby:9.3
+              docker_image:
+                - "cimg/ruby:3.1"
+                - "cimg/ruby:3.4"
+                - "jruby:9.4"
+                - "jruby:10"

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -1,0 +1,44 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.1', '3.4', 'jruby-9.4', 'jruby-10']
+
+    services:
+      rabbitmq:
+        image: rabbitmq
+        ports:
+          - 5672:5672
+        # GHA natively waits for the service to be healthy, replacing `dockerize`
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          # This automatically runs `bundle install` and caches the gems for faster runs!
+          bundler-cache: true
+
+      - name: Which bundler?
+        run: bundle -v
+
+      - name: RSpec
+        run: bundle exec rspec

--- a/active_publisher.gemspec
+++ b/active_publisher.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'bunny', '~> 2.1'
   end
 
-  spec.add_dependency 'activesupport', '>= 3.2'
+  spec.required_ruby_version = '>= 3.1.0'
+
+  spec.add_dependency 'activesupport', '>= 6.0'
   spec.add_dependency 'concurrent-ruby'
-  spec.add_dependency 'multi_op_queue', '>= 0.2.0'
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler"

--- a/lib/active_publisher/async/in_memory_adapter.rb
+++ b/lib/active_publisher/async/in_memory_adapter.rb
@@ -1,9 +1,9 @@
-require "active_publisher/message"
 require "active_publisher/async/in_memory_adapter/async_queue"
 require "active_publisher/async/in_memory_adapter/channel"
 require "active_publisher/async/in_memory_adapter/consumer_thread"
+require "active_publisher/message"
+require "active_publisher/multi_op_queue"
 require "concurrent"
-require "multi_op_queue"
 
 module ActivePublisher
   module Async

--- a/lib/active_publisher/async/in_memory_adapter/async_queue.rb
+++ b/lib/active_publisher/async/in_memory_adapter/async_queue.rb
@@ -20,7 +20,7 @@ module ActivePublisher
           self.back_pressure_strategy = back_pressure_strategy
           @max_queue_size = max_queue_size
           @supervisor_interval = supervisor_interval
-          @queue = ::MultiOpQueue::Queue.new
+          @queue = ::ActivePublisher::MultiOpQueue::Queue.new
           @consumers = {}
           create_and_supervise_consumers!
         end

--- a/lib/active_publisher/async/redis_adapter.rb
+++ b/lib/active_publisher/async/redis_adapter.rb
@@ -1,7 +1,7 @@
 require "active_publisher"
-require "active_publisher/message"
 require "active_publisher/async/redis_adapter/consumer"
-require "multi_op_queue"
+require "active_publisher/message"
+require "active_publisher/multi_op_queue"
 
 module ActivePublisher
   module Async
@@ -26,7 +26,7 @@ module ActivePublisher
           # do something with supervision ?
           @redis_pool = new_redis_pool
           @async_queue = ::ActivePublisher::Async::RedisAdapter::Consumer.new(redis_pool)
-          @queue = ::MultiOpQueue::Queue.new
+          @queue = ::ActivePublisher::MultiOpQueue::Queue.new
           @flush_max = ::ActivePublisher.configuration.messages_per_batch
           @flush_min = @flush_max / 2
 

--- a/lib/active_publisher/configuration.rb
+++ b/lib/active_publisher/configuration.rb
@@ -84,9 +84,9 @@ module ActivePublisher
       absolute_config_path = ::File.expand_path(::File.join("config", "active_publisher.yml"))
       action_subscriber_config_file = ::File.expand_path(::File.join("config", "action_subscriber.yml"))
 
-      if ::File.exists?(absolute_config_path)
+      if ::File.exist?(absolute_config_path)
         yaml_config = load_yaml_config_from_file(absolute_config_path)[env]
-      elsif ::File.exists?(action_subscriber_config_file)
+      elsif ::File.exist?(action_subscriber_config_file)
         yaml_config = load_yaml_config_from_file(action_subscriber_config_file)[env]
       end
 

--- a/lib/active_publisher/multi_op_queue.rb
+++ b/lib/active_publisher/multi_op_queue.rb
@@ -1,0 +1,203 @@
+module ActivePublisher
+  module MultiOpQueue
+    # Original Queue implementation from Ruby-2.0.0
+    # https://github.com/ruby/ruby/blob/ruby_2_0_0/lib/thread.rb
+    #
+    # This class provides a way to synchronize communication between threads.
+    #
+    # Example:
+    #
+    #   require 'thread'
+    #
+    #   queue = Queue.new
+    #
+    #   producer = Thread.new do
+    #     5.times do |i|
+    #       sleep rand(i) # simulate expense
+    #       queue << i
+    #       puts "#{i} produced"
+    #     end
+    #   end
+    #
+    #   consumer = Thread.new do
+    #     5.times do |i|
+    #       value = queue.pop
+    #       sleep rand(i/2) # simulate expense
+    #       puts "consumed #{value}"
+    #     end
+    #   end
+    #
+    #   consumer.join
+    #
+    class Queue
+      #
+      # Creates a new queue.
+      #
+      def initialize
+        @que = []
+        @num_waiting = 0
+        @mutex = Mutex.new
+        @cond = ConditionVariable.new
+      end
+
+      #
+      # Concatenates +ary+ onto the queue.
+      #
+      def concat(ary)
+        handle_interrupt do
+          @mutex.synchronize do
+            @que.concat ary
+            @cond.signal
+          end
+        end
+      end
+
+      #
+      # Pushes +obj+ to the queue.
+      #
+      def push(obj)
+        handle_interrupt do
+          @mutex.synchronize do
+            @que.push obj
+            @cond.signal
+          end
+        end
+      end
+
+      #
+      # Alias of push
+      #
+      alias << push
+
+      #
+      # Alias of push
+      #
+      alias enq push
+
+      #
+      # Retrieves data from the queue.  If the queue is empty, the calling thread is
+      # suspended until data is pushed onto the queue.  If +non_block+ is true, the
+      # thread isn't suspended, and an exception is raised.
+      #
+      def pop(non_block=false)
+        handle_interrupt do
+          @mutex.synchronize do
+            while true
+              if @que.empty?
+                if non_block
+                  raise ThreadError, "queue empty"
+                else
+                  begin
+                    @num_waiting += 1
+                    @cond.wait @mutex
+                  ensure
+                    @num_waiting -= 1
+                  end
+                end
+              else
+                return @que.shift
+              end
+            end
+          end
+        end
+      end
+
+      #
+      # Alias of pop
+      #
+      alias shift pop
+
+      #
+      # Alias of pop
+      #
+      alias deq pop
+
+      #
+      # Retrieves data from the queue and returns array of contents.
+      # If +num_to_pop+ are available in the queue then multiple elements are returned in array response
+      # If the queue is empty, the calling thread is
+      # suspended until data is pushed onto the queue.  If +non_block+ is true, the
+      # thread isn't suspended, and an exception is raised.
+      #
+      def pop_up_to(num_to_pop = 1, opts = {})
+        case opts
+        when TrueClass, FalseClass
+          non_bock = opts
+        when Hash
+          timeout = opts.fetch(:timeout, nil)
+          non_block = opts.fetch(:non_block, false)
+        end
+
+        handle_interrupt do
+          @mutex.synchronize do
+            while true
+              if @que.empty?
+                if non_block
+                  raise ThreadError, "queue empty"
+                else
+                  begin
+                    @num_waiting += 1
+                    @cond.wait(@mutex, timeout)
+                    return nil if @que.empty?
+                  ensure
+                    @num_waiting -= 1
+                  end
+                end
+              else
+                return @que.shift(num_to_pop)
+              end
+            end
+          end
+        end
+      end
+
+      #
+      # Returns +true+ if the queue is empty.
+      #
+      def empty?
+        @que.empty?
+      end
+
+      #
+      # Removes all objects from the queue.
+      #
+      def clear
+        @que.clear
+      end
+
+      #
+      # Returns the length of the queue.
+      #
+      def length
+        @que.length
+      end
+
+      #
+      # Alias of length.
+      #
+      alias size length
+
+      #
+      # Returns the number of threads waiting on the queue.
+      #
+      def num_waiting
+        @num_waiting
+      end
+
+      private
+
+      def handle_interrupt
+        @handle_interrupt = Thread.respond_to?(:handle_interrupt) if @handle_interrupt.nil?
+
+        if @handle_interrupt
+          Thread.handle_interrupt(StandardError => :on_blocking) do
+            yield
+          end
+        else
+          yield
+        end
+      end
+    end
+  end
+
+end

--- a/lib/active_publisher/version.rb
+++ b/lib/active_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActivePublisher
-  VERSION = "1.5.0.pre"
+  VERSION = "1.6.0.pre1"
 end

--- a/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
+++ b/spec/lib/active_publisher/async/in_memory_adapter_spec.rb
@@ -159,23 +159,36 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
     end
 
     describe "#create_consumer" do
+      let(:event_name) { "message_published.active_publisher" }
       it "can successfully publish a message" do
-        expect(::ActiveSupport::Notifications).to receive(:instrument)
-                                                    .with("message_published.active_publisher", :route => "test", :message_count => 1)
-        expect(consumer).to receive(:publish_all).with(exchange_name, [message]).and_call_original
-        subject.push(message)
-        sleep 0.1 # Await results
-      end
+        captured_payload = nil
+        callback = ->(_name, _start, _finish, _id, payload) { captured_payload = payload }
 
-      describe "when publish confirms enabled" do
-        it "notifies active support with an instrumentation" do
-          ::ActivePublisher.configuration.publisher_confirms = true
-          expect(::ActiveSupport::Notifications).to receive(:instrument)
-                                                    .with("message_published.active_publisher", :route => "test", :message_count => 1)
-          expect(::ActiveSupport::Notifications).to receive(:instrument).with("publishes_confirmed.active_publisher")
+        ::ActiveSupport::Notifications.subscribed(callback, event_name) do
           expect(consumer).to receive(:publish_all).with(exchange_name, [message]).and_call_original
           subject.push(message)
           sleep 0.1 # Await results
+        end
+
+        expect(captured_payload).to eq(route: "test", :message_count => 1)
+      end
+
+      describe "when publish confirms enabled" do
+        let(:pub_confirm) { "publishes_confirmed.active_publisher" }
+        it "notifies active support with an instrumentation" do
+          captured_payload = nil
+          callback = ->(_name, _start, _finish, _id, payload) { captured_payload = payload }
+
+          ::ActivePublisher.configuration.publisher_confirms = true
+
+          ::ActiveSupport::Notifications.subscribed(callback, pub_confirm) do
+            expect(consumer).to receive(:publish_all).with(exchange_name, [message]).and_call_original
+            subject.push(message)
+            sleep 0.1 # Await results
+          end
+
+          # An empty hash is expected
+          expect(captured_payload).to eq({})
         end
       end
 
@@ -283,7 +296,7 @@ describe ::ActivePublisher::Async::InMemoryAdapter::Adapter do
 
     describe "#push" do
       context "when the queue has room" do
-        before { allow(::MultiOpQueue::Queue).to receive(:new).and_return(mock_queue) }
+        before { allow(::ActivePublisher::MultiOpQueue::Queue).to receive(:new).and_return(mock_queue) }
 
         it "successfully adds to the queue" do
           expect(mock_queue).to receive(:push).with(message)

--- a/spec/lib/active_publisher/connection_spec.rb
+++ b/spec/lib/active_publisher/connection_spec.rb
@@ -20,7 +20,7 @@ describe ::ActivePublisher::Connection do
 
     it "can deliver an on_blocked message" do
       expect(::ActiveSupport::Notifications).to receive(:instrument).
-        with("connection_blocked.active_publisher", :reason => reason)
+        with("connection_blocked.active_publisher", {:reason => reason})
 
       # NOTE: Trigger the receiving of a blocked message from the broker.
       # It's a bit of a hack but it is a more realistic test without changing

--- a/spec/lib/active_publisher/multi_op_queue_spec.rb
+++ b/spec/lib/active_publisher/multi_op_queue_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe ::ActivePublisher::MultiOpQueue::Queue do
+  before do
+    @queue = ::ActivePublisher::MultiOpQueue::Queue.new
+  end
+
+  describe "#concat" do
+    it "pushes all of the array elements onto the queue" do
+      @queue.concat([1, 2, 3])
+      expect(@queue.size).to eq(3)
+    end
+
+    it "keeps the order for pop of the array" do
+      @queue.concat([1, 2, 3])
+      expect(@queue.pop).to eq(1)
+      expect(@queue.pop).to eq(2)
+      expect(@queue.pop).to eq(3)
+    end
+  end
+
+  describe "#size" do
+    it "returns 0 when queue is empty" do
+      expect(@queue.size).to eq(0)
+    end
+
+    it "returns the number of items present when queue is not empty" do
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+      expect(@queue.size).to eq(5)
+    end
+  end
+
+  describe "#pop_up_to" do
+    it "returns an array of 1 element when 1 element present" do
+      @queue.push(1)
+      expect(@queue.pop_up_to).to eq([1])
+    end
+
+    it "returns an array of the pop_up_to number when present" do
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+      @queue.push(1)
+
+      expect(@queue.pop_up_to(3)).to eq([1, 1, 1])
+    end
+
+    it "supports an optional timeout" do
+      start = Time.now.to_f
+      expect(@queue.pop_up_to(5, timeout: 0.1)).to be_nil
+      expect(Time.now.to_f - start).to be_within(0.01).of(0.1)
+    end
+
+    it "blocks until items are available" do
+      start = Time.now.to_f
+      Thread.new { sleep 0.1; @queue.push(3) }
+      expect(@queue.pop_up_to(5, timeout: 0.5)).to eq([3])
+      expect(Time.now.to_f - start).to be_within(0.01).of(0.1)
+    end
+  end
+end


### PR DESCRIPTION
Remove the external dependency on `multi_op_queue`.
Moved `multi_op_queue` code internal.
Removed `.taint` method.
Reworked spec to use Rspec.